### PR TITLE
fix: scope resolvedOwn so the post-connect notification doesn't throw

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1706,12 +1706,12 @@ async function connectWhatsApp(): Promise<void> {
       reconnectAttempt = 0
       pairingCodeRequested = false
       ownJid = jidNormalizedUser(sock!.user?.id ?? '')
+      const resolvedOwn = ownJid ? resolveToPhone(ownJid) : ''
       process.stderr.write(`${LOG_PREFIX}: connected as ${ownJid}\n`)
 
       // Auto-add owner to allowlist on first connection
       if (ownJid && !STATIC) {
         const access = loadAccess()
-        const resolvedOwn = resolveToPhone(ownJid)
         if (!isAllowedJid(ownJid, access.allowFrom)) {
           access.allowFrom.push(resolvedOwn)
           if (access.dmPolicy === 'pairing' && access.allowFrom.length > 0) {


### PR DESCRIPTION
## Problem

Every successful WhatsApp connection logs:

```
whatsapp channel: unhandled rejection: ReferenceError: resolvedOwn is not defined
```

and the post-pairing confirmation notification ("WhatsApp paired and connected as … / Ready to receive messages") never reaches the Claude session.

## Root cause

In the `connection === 'open'` handler, `resolvedOwn` is `const`-declared **inside** the `if (ownJid && !STATIC)` block:

```ts
if (ownJid && !STATIC) {
  const access = loadAccess()
  const resolvedOwn = resolveToPhone(ownJid)   // block-scoped
  ...
}
```

but it is then referenced in the `mcp.notification(...)` call that lives **outside** that block:

```ts
mcp.notification({
  ...
  content: [ `WhatsApp paired and connected as ${resolvedOwn}.`, ... ].join('\n'),
})
```

`resolvedOwn` is out of scope at the notification site, so building the payload throws `ReferenceError`. The throw happens inside the async `connection.update` handler, so it surfaces via `process.on('unhandledRejection')` rather than crashing — which is why the connection still works but the confirmation silently never sends. It fires on every `open`, including reconnects.

## Fix

Hoist `resolvedOwn` to the handler scope so both the allowlist write and the notification can read it:

```diff
       ownJid = jidNormalizedUser(sock!.user?.id ?? '')
+      const resolvedOwn = ownJid ? resolveToPhone(ownJid) : ''
       process.stderr.write(`${LOG_PREFIX}: connected as ${ownJid}\n`)

       // Auto-add owner to allowlist on first connection
       if (ownJid && !STATIC) {
         const access = loadAccess()
-        const resolvedOwn = resolveToPhone(ownJid)
         if (!isAllowedJid(ownJid, access.allowFrom)) {
```

One-line change in intent; no other behaviour altered.

## Test plan

- **Fresh pair** (no existing `~/.whatsapp-channel/.baileys_auth`): server connects, `creds.registered` → `true`, **no** `ReferenceError` in stderr, and the "Ready to receive messages" notification is emitted on `notifications/claude/channel`.
- **Reconnect** with saved creds: connects with no pairing code and no rejection.

Verified locally on macOS / Bun 1.3.14 against this exact connection path.

## Optional follow-up (not in this PR)

Before this fix the notification always threw, so it never sent. After the fix it sends on **every** `connection: 'open'`, including reconnects — the onboarding text ("auto-added to allowlist", "Ready to receive messages") can read oddly on a routine reconnect. If that's undesirable, consider gating it to first-connection only. Left out here to keep the change minimal.
