### PR TITLE
fix(pairing): re-register pairing code on reconnect

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1678,10 +1678,48 @@ let reconnectAttempt = 0
 
 let pairingCodeRequested = false
 let lastPairingCode = ''
+// Bumped per socket. WhatsApp only honours a pairing code on the socket that
+// registered it, so a request started by a superseded socket must not touch
+// shared pairing state.
+let pairingGeneration = 0
+
+// Registers `lastPairingCode` (or a fresh one) on `targetSock` and tells the
+// user. Reusing the existing code keeps whatever we already showed them valid
+// across reconnects, so they don't have to retype on every 428.
+async function requestAndAnnouncePairingCode(targetSock: NonNullable<typeof sock>): Promise<void> {
+  const code = await targetSock.requestPairingCode(PHONE_NUMBER!, lastPairingCode || undefined)
+  const isNewCode = code !== lastPairingCode
+  lastPairingCode = code
+
+  const pairingMsg =
+    `Pairing code: ${code}\n` +
+    `Open WhatsApp > Linked Devices > Link a Device\n` +
+    `Tap "Link with phone number instead"\n` +
+    `Enter the code above`
+  process.stderr.write(`${LOG_PREFIX}: ${pairingMsg}\n`)
+
+  // Re-registering an unchanged code is routine during pairing — only surface
+  // it to the session when there is actually something new to type.
+  if (!isNewCode) return
+  mcp.notification({
+    method: 'notifications/claude/channel',
+    params: {
+      content: pairingMsg,
+      meta: {
+        chat_id: 'system',
+        message_id: `pairing-${Date.now()}`,
+        user: 'WhatsApp Setup',
+        user_id: 'system',
+        ts: new Date().toISOString(),
+      },
+    },
+  }).catch(() => {})
+}
 
 async function connectWhatsApp(): Promise<void> {
   const { state, saveCreds } = await useMultiFileAuthState(AUTH_DIR)
   const needsPairing = !state.creds.registered
+  const myGeneration = ++pairingGeneration
 
   sock = makeWASocket({
     auth: state,
@@ -1711,34 +1749,14 @@ async function connectWhatsApp(): Promise<void> {
     ;(async () => {
       // Small delay to let the WebSocket handshake begin
       await new Promise(r => setTimeout(r, 5000))
+      if (myGeneration !== pairingGeneration) return
       if (pairingCodeRequested) return
       pairingCodeRequested = true
       try {
-        const code = await localSock.requestPairingCode(PHONE_NUMBER)
-        lastPairingCode = code
-        const pairingMsg =
-          `Pairing code: ${code}\n` +
-          `Open WhatsApp > Linked Devices > Link a Device\n` +
-          `Tap "Link with phone number instead"\n` +
-          `Enter the code above`
-        process.stderr.write(`${LOG_PREFIX}: ${pairingMsg}\n`)
-        // Surface pairing code to Claude session via MCP notification
-        mcp.notification({
-          method: 'notifications/claude/channel',
-          params: {
-            content: pairingMsg,
-            meta: {
-              chat_id: 'system',
-              message_id: `pairing-${Date.now()}`,
-              user: 'WhatsApp Setup',
-              user_id: 'system',
-              ts: new Date().toISOString(),
-            },
-          },
-        }).catch(() => {})
+        await requestAndAnnouncePairingCode(localSock)
       } catch (err) {
         // Will retry on next connectWhatsApp call
-        pairingCodeRequested = false
+        if (myGeneration === pairingGeneration) pairingCodeRequested = false
         process.stderr.write(`${LOG_PREFIX}: pairing code request failed: ${err}\n`)
       }
     })()
@@ -1758,28 +1776,9 @@ async function connectWhatsApp(): Promise<void> {
       // QR event fired (works in Node.js) — also request pairing code as alternative
       pairingCodeRequested = true
       try {
-        const code = await sock!.requestPairingCode(PHONE_NUMBER)
-        lastPairingCode = code
-        const pairingMsg =
-          `Pairing code: ${code}\n` +
-          `Open WhatsApp > Linked Devices > Link a Device\n` +
-          `Tap "Link with phone number instead"\n` +
-          `Enter the code above`
-        process.stderr.write(`${LOG_PREFIX}: ${pairingMsg}\n`)
-        mcp.notification({
-          method: 'notifications/claude/channel',
-          params: {
-            content: pairingMsg,
-            meta: {
-              chat_id: 'system',
-              message_id: `pairing-${Date.now()}`,
-              user: 'WhatsApp Setup',
-              user_id: 'system',
-              ts: new Date().toISOString(),
-            },
-          },
-        }).catch(() => {})
+        await requestAndAnnouncePairingCode(sock!)
       } catch (err) {
+        if (myGeneration === pairingGeneration) pairingCodeRequested = false
         process.stderr.write(`${LOG_PREFIX}: pairing code request failed: ${err}\n`)
       }
     }
@@ -1840,6 +1839,11 @@ async function connectWhatsApp(): Promise<void> {
 
     if (connection === 'close') {
       sock = null
+      // A dead socket can never complete pairing: WhatsApp drops the code it
+      // registered for us along with the connection. Clear the flag so the
+      // reconnect below re-registers it, otherwise we keep showing the user a
+      // code that nothing is listening for.
+      pairingCodeRequested = false
       const statusCode = (lastDisconnect?.error as any)?.output?.statusCode
       const reason = statusCode ?? 'unknown'
       process.stderr.write(`${LOG_PREFIX}: disconnected (reason: ${reason})\n`)


### PR DESCRIPTION
## The problem

Pairing codes fail every time. The user is shown a code, types it into WhatsApp, and it is rejected — repeatedly, across restarts.

## Root cause

`requestPairingCode()` registers the code by sending a `link_code_companion_reg` IQ **over the live socket** ([Baileys `socket.js:596`](https://github.com/WhiskeySockets/Baileys/blob/master/src/Socket/socket.ts)). The code only exists for the lifetime of the connection that registered it.

During pairing, WhatsApp issues 428 disconnects. `server.ts` already expects this and reconnects with backoff:

```ts
// During pairing, 428 is expected — gentle backoff, retry will re-request pairing code
if (statusCode === 428) {
  reconnectAttempt++
  setTimeout(connectWhatsApp, delay)
```

**But the retry never re-requests the code.** `pairingCodeRequested` is set `true` before the first request and only cleared on a thrown error or on `connection === 'open'` — neither of which happens on a 428. So the reconnect hits:

```ts
if (needsPairing && PHONE_NUMBER && !pairingCodeRequested) {  // false → skipped
```

Every socket after the first has **no code registered at all**, while the `status` tool keeps reporting the stale `lastPairingCode` indefinitely.

The result is an unwinnable race: the socket dies within ~10s, while opening WhatsApp → Linked Devices → Link with phone number → typing the code takes 30–60s. By the time the code is entered, nothing is listening for it.

This is observable in session transcripts as **exactly one code per server boot**, never re-minted, no matter how many reconnects occur.

## The fix

1. **Clear the latch on close.** A dead socket can never complete pairing, so every reconnect now re-registers the code. This is the actual bug.
2. **Reuse the code string.** `requestPairingCode()` accepts an optional `customPairingCode`, so passing the previous code back keeps whatever was already shown to the user valid across reconnects instead of rotating it under them. The session is only notified when the code genuinely changes.
3. **Per-socket generation counter.** Without this, (1) opens a race where a superseded socket's failing request clears the latch belonging to the live socket.

## Testing

- `bun build server.ts --target=bun` passes.
- Behaviour traced against the Baileys 7.0.0-rc.9 `requestPairingCode` implementation vendored in this repo.
- Not yet confirmed end-to-end against a real phone — I'd welcome a second pair of eyes on the reconnect path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)