### PR TITLE
feat(reply): support @-mentions

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -267,6 +267,35 @@ function resolveToPhone(jid: string): string {
   return lidMap[jidNormalizedUser(jid)] ?? jid
 }
 
+// ─── Outbound mentions ──────────────────────────────────────────────
+// Writing "@12345" in the text is not enough: WhatsApp only renders a mention —
+// and only notifies the person — when the message also carries a `mentions`
+// array of JIDs. Without it the @ is inert text. Accept ids in whatever shape
+// the caller has (bare, @-prefixed, LID or phone, full JID) and normalise.
+function normalizeMentionJids(raw: string[]): string[] {
+  const out: string[] = []
+  for (const entry of raw) {
+    const s = String(entry ?? '').trim().replace(/^@/, '')
+    if (!s) continue
+    if (s.includes('@')) { out.push(jidNormalizedUser(s)); continue }
+    // Group participants are LID-addressed, and the text convention is "@<lid>",
+    // so prefer the LID form whenever we know it.
+    const asLid = `${s}@lid`
+    if (lidMap[asLid]) { out.push(asLid); continue }
+    const lidForPhone = Object.keys(lidMap).find(k => lidMap[k] === `${s}@s.whatsapp.net`)
+    out.push(lidForPhone ?? `${s}@s.whatsapp.net`)
+  }
+  return [...new Set(out)]
+}
+
+// A long reply is split into chunks; only attach a mention to the chunk whose
+// text actually references it, so nobody gets pinged once per chunk.
+function mentionsForChunk(text: string, all: string[]): string[] | undefined {
+  if (!all.length) return undefined
+  const hits = all.filter(jid => text.includes(`@${jid.split('@')[0]}`))
+  return hits.length ? hits : undefined
+}
+
 // Our own lidMap is only populated passively, by the `lid-mapping.update`
 // event (see connectWhatsApp). That event does not reliably fire for every
 // contact, which left allowlisted senders permanently unresolvable — and
@@ -939,7 +968,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'reply',
       description:
-        'Reply on WhatsApp. Pass chat_id from the inbound message. Optionally pass reply_to (message_id) for quoting, and files (absolute paths) to attach images or documents.',
+        'Reply on WhatsApp. Pass chat_id from the inbound message. Optionally pass reply_to (message_id) for quoting, mentions (to @-tag people) and files (absolute paths) to attach images or documents.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -948,6 +977,12 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
           reply_to: {
             type: 'string',
             description: 'Message ID to quote-reply. Use message_id from the inbound <channel> block.',
+          },
+          mentions: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'User ids to @-tag, e.g. ["210363773620264"] — the user_id/lid from an inbound <channel> block (a phone number or full JID also works). You MUST also write the matching "@<id>" into text, using the same id you pass here; the array is what makes WhatsApp render it as a real mention and notify them, the text alone does nothing.',
           },
           files: {
             type: 'array',
@@ -1036,6 +1071,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
         const text = args.text as string
         const reply_to = args.reply_to as string | undefined
         const files = (args.files as string[] | undefined) ?? []
+        const mentionJids = normalizeMentionJids((args.mentions as string[] | undefined) ?? [])
 
         assertAllowedChat(chat_id)
         if (!sock) throw new Error('WhatsApp not connected')
@@ -1065,7 +1101,12 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
           writeFileSync(docPath, text)
           const preview = markdownToWhatsApp(text.slice(0, 200) + (text.length > 200 ? '…' : ''))
           const opts = quotedMsg ? { quoted: quotedMsg } : undefined
-          const sent = await sock.sendMessage(chat_id, { text: preview }, opts ?? undefined)
+          const previewMentions = mentionsForChunk(preview, mentionJids)
+          const sent = await sock.sendMessage(
+            chat_id,
+            previewMentions ? { text: preview, mentions: previewMentions } : { text: preview },
+            opts ?? undefined,
+          )
           if (sent?.key) { trackSent(sent.key); if (sent.key.id) sentIds.push(sent.key.id) }
           const docSent = await sock.sendMessage(chat_id, {
             document: readFileSync(docPath),
@@ -1084,7 +1125,12 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
             (replyMode === 'all' || i === 0)
           const opts = shouldQuote && quotedMsg ? { quoted: quotedMsg } : undefined
           const formatted = markdownToWhatsApp(chunks[i])
-          const sent = await sock.sendMessage(chat_id, { text: formatted }, opts ?? undefined)
+          const chunkMentions = mentionsForChunk(formatted, mentionJids)
+          const sent = await sock.sendMessage(
+            chat_id,
+            chunkMentions ? { text: formatted, mentions: chunkMentions } : { text: formatted },
+            opts ?? undefined,
+          )
           if (sent?.key) {
             trackSent(sent.key)
             if (sent.key.id) sentIds.push(sent.key.id)


### PR DESCRIPTION
## The problem

The `reply` tool cannot tag anyone, and fails silently when asked to.

Writing `@12345` into the message text renders as literal text and notifies nobody. WhatsApp/Baileys only create a real mention when `sendMessage` is passed a **`mentions` array of JIDs**. `server.ts` sends `sock.sendMessage(chat_id, { text })` with no `mentions`, and the `reply` tool had no parameter to supply one — it *reads* `mentionedJid` (for the require-mention gate) but never writes one.

So an agent asked to "tag Lisa so she sees this" produces a message that looks correct in the transcript, reports success, and pings no one. That is the worst shape a bug can take: the caller believes the notification went out.

## The fix

Add an optional `mentions` array to the `reply` tool.

- **Lenient input, canonical output.** Ids are accepted in whatever shape the caller has — bare, `@`-prefixed, LID or phone, or a full JID — and normalised through `lidMap`. The `@lid` form is preferred because group participants are LID-addressed and the in-text convention is `@<lid>`; that is how inbound mentions already arrive, so round-tripping an id from an inbound `<channel>` block works without the caller knowing anything about LIDs.
- **Sensible fallbacks.** Unknown numbers fall back to `<n>@s.whatsapp.net`, duplicates collapse, junk drops.
- **Per-chunk targeting.** A long reply is split into chunks; a mention is attached only to the chunk whose text actually references it, so nobody gets pinged once per chunk. Both text paths (normal chunked send and the document-mode preview) pass them through.

The array and the text must agree — the tool description states this explicitly, since the array alone renders nothing and the text alone notifies nobody.

## Testing

- `node --experimental-strip-types --check server.ts` passes.
- `normalizeMentionJids` verified against a real `lid-map.json`: lid / `@lid` / phone / full JID all collapse to the same `<lid>@lid`; unknown numbers fall back to `@s.whatsapp.net`; duplicates dedupe; junk drops.
- Exercised end-to-end in a live group: a reply carrying `mentions` sends and delivers.
- **Caveat:** I could not programmatically verify the *rendered* mention, as there is no read-back of a sent message's `mentionedJid` — delivery and normalisation are confirmed, the highlight/notification was confirmed only by eye.

Independent of #5 and #6 — this touches only the reply path and the two helpers above, and shares no lines with the pairing work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
