### PR TITLE
fix(pairing): run server under node and keep the WA Web version current

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "bin": "./server.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "start": "bun install --no-summary && bun server.ts",
+    "start": "bun install --no-summary && node --experimental-strip-types server.ts",
     "postinstall": "node patch-baileys.mjs"
   },
   "type": "module"

--- a/patch-baileys.mjs
+++ b/patch-baileys.mjs
@@ -62,18 +62,41 @@ patch(
 )
 
 // Patch 4: update WA Web version (405 fix)
-patch(
-  'Defaults/index.js',
-  '1027934701',
-  '1034074495',
-  'WA Web version (Defaults)'
-)
+//
+// WA rejects builds it considers too old with a 405 "Connection Failure" during
+// the handshake, before any QR or pairing code can be registered — so a stale
+// value here surfaces as "couldn't link device" on the phone, not as a version
+// error. Matching on the build number by regex rather than by a hardcoded old
+// value keeps this working whatever rc.9 ships, and makes a bump a one-line
+// change to WA_VERSION below.
+//
+// Current value from Baileys' own source of truth:
+//   https://raw.githubusercontent.com/WhiskeySockets/Baileys/master/src/Defaults/baileys-version.json
+const WA_VERSION = '1035194821'
 
-patch(
-  'Utils/generics.js',
-  '1027934701',
-  '1034074495',
-  'WA Web version (generics)'
-)
+function patchVersion(file, label) {
+  const path = join(baileys, file)
+  if (!existsSync(path)) {
+    console.log(`  skip: ${file} not found`)
+    return
+  }
+  const src = readFileSync(path, 'utf8')
+  // `[2, 3000, <build>]` — the only shape the version literal takes in rc.9
+  const re = /(\[\s*2\s*,\s*3000\s*,\s*)(\d{9,})(\s*\])/
+  const found = src.match(re)
+  if (!found) {
+    console.log(`  warn: ${label} — version literal not found, may need manual review`)
+    return
+  }
+  if (found[2] === WA_VERSION) {
+    console.log(`  ok: ${label} (already ${WA_VERSION})`)
+    return
+  }
+  writeFileSync(path, src.replace(re, `$1${WA_VERSION}$3`))
+  console.log(`  patched: ${label} (${found[2]} -> ${WA_VERSION})`)
+}
+
+patchVersion('Defaults/index.js', 'WA Web version (Defaults)')
+patchVersion('Utils/generics.js', 'WA Web version (generics)')
 
 console.log('done.')


### PR DESCRIPTION
Two independent reasons a clean install cannot complete device pairing. Neither touches `server.ts`, so this does not overlap #5 or #6.

## 1. Bun cannot open the WhatsApp socket (`package.json`)

`start` runs `bun server.ts`, but Bun 1.3.14 cannot complete the WebSocket upgrade to `wss://web.whatsapp.com/ws/chat` — its `ws` shim rejects the correct handshake response with `Unexpected server response: 101`. Node 22 opens the same socket in ~47ms.

The failure mode is what makes this expensive to diagnose: Baileys persists creds **before** awaiting the network send, and the socket error never surfaces as a `connection.update`. So the server logs `starting`, writes a pairing code into `.baileys_auth/creds.json`, and then hangs forever — no code printed, no error, no disconnect. It presents as "the pairing code never appeared", which sends you looking at the pairing logic rather than at the runtime.

`server.ts` uses no Bun-specific APIs, so node runs it unchanged:

```diff
- "start": "bun install --no-summary && bun server.ts"
+ "start": "bun install --no-summary && node --experimental-strip-types server.ts"
```

`bun install` is kept — only the execution moves to node.

## 2. Stale WA Web version → 405 (`patch-baileys.mjs`)

WhatsApp rejects builds it considers too old with a 405 "Connection Failure" during the handshake, *before* a QR or pairing code can be registered — so a stale value here also surfaces as "couldn't link device" on the phone, not as a version error. Same visible symptom as (1), different cause, which is why they are together.

Patch 4 pinned both the old and new build numbers as string literals, so it silently no-ops the moment upstream ships anything else. This matches the version literal (`[2, 3000, <build>]`) by regex instead, and lifts the target into a single `WA_VERSION` const so a future bump is a one-line change. Value taken from Baileys' own source of truth, [`baileys-version.json`](https://raw.githubusercontent.com/WhiskeySockets/Baileys/master/src/Defaults/baileys-version.json).

It now reports what it did (`patched: … (1034074495 -> 1035194821)`), warns rather than silently doing nothing if the literal is not found, and stays idempotent — it is a postinstall script that must be safe to re-run.

## Testing

- `node --check patch-baileys.mjs` passes; the version patch is idempotent across re-runs.
- Both changes have been running in a live deployment since 2026-07-14: the socket connects and the session is paired and serving real traffic under node at this WA version. The silent pairing hang described above has not recurred since.
- **Not tested on Windows**, and I have not checked whether Bun's `ws` behaviour differs across Bun versions. If you'd rather keep Bun as the runtime, the real fix likely belongs upstream in Bun's `ws` shim and this is a workaround rather than a cure — happy to split the two halves into separate PRs if you want them judged independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
