### PR TITLE
fix: fetch WhatsApp Web version at runtime instead of hardcoding (fixes 405 pairing failure)

### DIFF
--- a/patch-baileys.mjs
+++ b/patch-baileys.mjs
@@ -5,7 +5,10 @@
  * 1. passive: true → false  (causes device_removed disconnect)
  * 2. delete lidDbMigrated    (unrecognized field, rejected by WA)
  * 3. remove await on noise.finishInit()  (race condition)
- * 4. update WA Web version (old version rejected with 405)
+ *
+ * NOTE: The WA Web version is intentionally NOT patched here anymore.
+ * server.ts calls fetchLatestBaileysVersion() at runtime, so the version
+ * stays current automatically and never goes stale (was causing 405).
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs'
@@ -59,21 +62,6 @@ patch(
   'await noise.finishInit()',
   'noise.finishInit()',
   'noise.finishInit race condition'
-)
-
-// Patch 4: update WA Web version (405 fix)
-patch(
-  'Defaults/index.js',
-  '1027934701',
-  '1034074495',
-  'WA Web version (Defaults)'
-)
-
-patch(
-  'Utils/generics.js',
-  '1027934701',
-  '1034074495',
-  'WA Web version (generics)'
 )
 
 console.log('done.')

--- a/server.ts
+++ b/server.ts
@@ -19,6 +19,7 @@ import {
 import { z } from 'zod'
 import makeWASocket, {
   useMultiFileAuthState,
+  fetchLatestBaileysVersion,
   DisconnectReason,
   downloadMediaMessage,
   getContentType,
@@ -1683,7 +1684,14 @@ async function connectWhatsApp(): Promise<void> {
   const { state, saveCreds } = await useMultiFileAuthState(AUTH_DIR)
   const needsPairing = !state.creds.registered
 
+  // Fetch the current WhatsApp Web version at runtime so it never goes stale.
+  // fetchLatestBaileysVersion() falls back to the bundled default if the
+  // network fetch fails, so this stays safe offline.
+  const { version, isLatest } = await fetchLatestBaileysVersion()
+  process.stderr.write(`${LOG_PREFIX}: using WA Web version ${version.join('.')} (isLatest: ${isLatest})\n`)
+
   sock = makeWASocket({
+    version,
     auth: state,
     printQRInTerminal: !PHONE_NUMBER, // QR only if no phone number set
     logger: silentLogger,


### PR DESCRIPTION
The hardcoded WhatsApp Web version in `patch-baileys.mjs` goes stale as WhatsApp bumps
the build, and WhatsApp then rejects pairing with `stream:error code 405`
("could not connect" on the phone). This replaces the hardcode with a runtime call to
`fetchLatestBaileysVersion()` (which falls back to the bundled default offline) and
removes the now-redundant version patches. Verified: pairing completes and the device
links after the change.

## Symptoms

```
whatsapp channel: Pairing code: XXXXXXXX
...
whatsapp channel baileys: {"fullErrorNode":{"tag":"stream:error","attrs":{"code":"405"}}}
whatsapp channel: disconnected (reason: 405)
whatsapp channel: reconnecting in ...
```

## Fix

- `server.ts`: call `fetchLatestBaileysVersion()` in `connectWhatsApp()` and pass the
  result into `makeWASocket({ version, ... })`.
- `patch-baileys.mjs`: remove the now-redundant hardcoded version patches (Patch 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)