### PR TITLE
chore: add contributing docs, issue/PR templates, and CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repo — auto-requested for review on every PR.
+* @Rich627

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: Bug report
+description: Something isn't working
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! For **security vulnerabilities**, please do NOT file a
+        public issue — see [SECURITY.md](../blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Plugin version
+      description: "From `.claude-plugin/plugin.json`, or the version shown by `plugin`."
+      placeholder: "e.g. 0.11.0"
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: OS, Bun version (`bun --version`), and how you run the server (Claude Code / watchdog / manual).
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant log output. **Redact phone numbers, auth data, and anything from `~/.whatsapp-channel/`.**
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Rich627/whatsapp-claude-plugin/security/advisories/new
+    about: Please report security issues privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do that's hard or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!-- Thanks for contributing! Please fill this out so your PR is easy to review. -->
+
+## What & why
+
+<!-- What does this change do, and why? Link any related issue (e.g. "Fixes #4"). -->
+
+## How I tested it
+
+<!-- This is a live WhatsApp bridge — describe the manual steps you ran. -->
+
+## Checklist
+
+- [ ] I ran `trunk fmt` and `trunk check` and it passes.
+- [ ] **Version bumped in BOTH files to the same new version** (patch = fix, minor = feature):
+  - [ ] `.claude-plugin/plugin.json` → `version`
+  - [ ] `.claude-plugin/marketplace.json` → `plugins[0].version` (the **inner** one — not the top-level marketplace version)
+- [ ] No new runtime dependencies (or I opened an issue to discuss first).
+- [ ] No runtime state / secrets committed (nothing from `~/.whatsapp-channel/`).
+- [ ] If I touched `server.ts` connection lifecycle, the singleton lock, or access/allowlist gating, I described the invariant I preserved above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  version-consistency:
+    name: Plugin versions match
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check plugin.json and marketplace.json versions match
+        run: |
+          plugin=$(jq -r '.version' .claude-plugin/plugin.json)
+          market=$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)
+          echo "plugin.json version:               $plugin"
+          echo "marketplace.json plugins[0].version: $market"
+          if [ "$plugin" != "$market" ]; then
+            echo "::error::Version mismatch. Bump BOTH .claude-plugin/plugin.json (.version) and .claude-plugin/marketplace.json (.plugins[0].version) to the SAME value. (The top-level marketplace version is separate — leave it alone.)"
+            exit 1
+          fi
+          echo "OK: versions match ($plugin)"
+
+  trunk:
+    name: Trunk check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Trunk Check
+        uses: trunk-io/trunk-action@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing
+
+Thanks for contributing to the WhatsApp MCP Server for Claude Code! This project is
+small and moves fast, so a few conventions keep pull requests easy to review and merge.
+
+## Project at a glance
+
+- **Runtime:** [Bun](https://bun.sh). TypeScript runs directly — there is **no build
+  step** and **no test suite**.
+- **Dependencies:** only two — `@modelcontextprotocol/sdk` and
+  `@whiskeysockets/baileys`. Baileys is pinned to a release candidate and patched by
+  `patch-baileys.mjs` (runs automatically on `postinstall`). **Please do not add new
+  runtime dependencies without opening an issue first** — a slim dependency tree is a
+  deliberate goal.
+- **The whole MCP server is one file:** `server.ts`.
+
+## Getting set up
+
+```bash
+bun install     # installs deps and runs patch-baileys.mjs via postinstall
+bun server.ts   # runs the MCP server
+```
+
+Runtime state (WhatsApp auth, access config, group data) lives in
+`~/.whatsapp-channel/`, created at runtime. **Never commit runtime state into the
+repo.**
+
+## Before you open a pull request
+
+1. **Format and lint with Trunk.** CI runs `trunk check` on every PR.
+
+   ```bash
+   trunk fmt      # auto-format
+   trunk check    # lint (prettier, markdownlint, shellcheck, shfmt, checkov, trufflehog)
+   ```
+
+2. **Bump the version — in BOTH files.** This is the single most common mistake in
+   PRs, and getting it wrong makes `plugin update` silently no-op for every user. You
+   must bump **both** of these to the **same** new version:
+
+   - `.claude-plugin/plugin.json` → `version`
+   - `.claude-plugin/marketplace.json` → `plugins[0].version` (the **inner** one)
+
+   > ⚠️ `marketplace.json` also has a **top-level** `version` field — that is the
+   > marketplace's own version. **Leave it alone.** Only the `plugins[0].version`
+   > needs to match `plugin.json`.
+
+   Quick check (should print two matching versions):
+
+   ```bash
+   grep -n '"version"' .claude-plugin/plugin.json .claude-plugin/marketplace.json
+   ```
+
+   Use semver: **patch** for fixes, **minor** for features. CI enforces that the two
+   versions match.
+
+3. **Be careful in `server.ts`'s sensitive areas.** Three areas have regressed before.
+   If your change touches any of them, please call out in the PR description what
+   invariant you preserved:
+
+   - **Connection lifecycle** (connect / reconnect / disconnect handling)
+   - **The singleton lock** (prevents duplicate/orphaned servers silently killing
+     replies)
+   - **Allowlist / access gating** (DM & group access control, LID↔phone mapping)
+
+   `server.ts` uses module-level state that spans the whole file, so `grep` the whole
+   file for every symbol you touch before changing it.
+
+## Pull request expectations
+
+- Keep PRs focused — one fix or feature per PR is much easier to review.
+- Describe **what** changed and **why**, and how you tested it (this is a live
+  WhatsApp bridge, so note the manual steps you ran).
+- The PR template checklist covers the version bump and `trunk check` — please tick it
+  honestly.
+
+## Reporting bugs & security issues
+
+- **Bugs / features:** open a GitHub issue using the templates.
+- **Security vulnerabilities:** please do **not** open a public issue — see
+  [`SECURITY.md`](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+This project bridges WhatsApp into Claude Code. A running instance holds **WhatsApp
+linked-device credentials** and can **send and receive messages as the linked account**,
+so security reports are taken seriously.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, use GitHub's private reporting:
+
+1. Go to the [**Security** tab](https://github.com/Rich627/whatsapp-claude-plugin/security)
+   of this repository.
+2. Click **Report a vulnerability** to open a private advisory.
+
+Please include:
+
+- A description of the issue and its impact.
+- Steps to reproduce (or a proof of concept).
+- Any affected version(s) or configuration.
+
+You can expect an initial response within a few days. Please give a reasonable window
+to fix the issue before any public disclosure.
+
+## Scope & things to keep in mind
+
+- Runtime secrets (WhatsApp auth, access config) live in `~/.whatsapp-channel/` and
+  must **never** be committed to the repository. If you find credentials or tokens in
+  the git history or in a PR, treat it as a security report.
+- Access control (DM/group allowlists, pairing codes, LID↔phone mapping) is a security
+  boundary. Bugs that let an unauthorized sender trigger the agent are in scope.
+- This is a hobbyist/community project with no formal SLA, but genuine reports will
+  always get a response.


### PR DESCRIPTION
Adds community health files now that the project is receiving external PRs.

## What's included
- **CONTRIBUTING.md** — the dual-file version bump, `trunk fmt`/`trunk check`, the two-dependency rule, and the `server.ts` danger zones (connection lifecycle, singleton lock, access gating).
- **SECURITY.md** — routes vulnerability reports to a private advisory (this bridges live WhatsApp credentials).
- **PR template** + **bug/feature issue templates** + issue config (blank issues off, security → private advisory).
- **CODEOWNERS** — auto-requests review on every PR.
- **CI** (`.github/workflows/ci.yml`) — two jobs:
  1. **version-consistency** — fails if `plugin.json` `.version` ≠ `marketplace.json` `.plugins[0].version`, machine-enforcing the #1 hard rule so external PRs can't silently no-op `plugin update`.
  2. **trunk check**.

## Notes
Docs/CI only — no runtime behavior change, so **no plugin version bump** (these files aren't shipped via `plugin update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)