### PR TITLE
ci: pin actions to SHAs and fix PR-template MD041

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 <!-- Thanks for contributing! Please fill this out so your PR is easy to review. -->
 
 ## What & why

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Plugin versions match
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Check plugin.json and marketplace.json versions match
         run: |
           plugin=$(jq -r '.version' .claude-plugin/plugin.json)
@@ -30,8 +30,8 @@ jobs:
     name: Trunk check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@04ba50e7658c81db7356da96657e6e77f220bfa3 # v1.3.1


### PR DESCRIPTION
Fixes the two `trunk check` failures the new CI surfaced on its own first run:

- **Pin actions to full commit SHAs** (`pinact/unpinned-action`, high) — `actions/checkout` → `34e1148…` (v4.3.1), `trunk-io/trunk-action` → `04ba50e…` (v1). Supply-chain hardening.
- **Disable `markdownlint/MD041` in the PR template** — its first line is an HTML comment (intentional for a template), not a heading.

Docs/CI only, no runtime change. Only touches `.github/workflows/ci.yml` and `.github/pull_request_template.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)