### PR TITLE
fix(lock): make the singleton lock and orphan check work on Windows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "whatsapp-claude-channel",
       "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control, pairing, allowlists, and group policy.",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "source": "./",
       "category": "channels"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "whatsapp-claude-channel",
   "displayName": "WhatsApp Channel for Claude Code",
   "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /whatsapp-claude-channel:access.",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": {
     "name": "Rich627"
   },

--- a/scripts/doctor.ts
+++ b/scripts/doctor.ts
@@ -56,23 +56,46 @@ function report(sev: Severity, id: string, msg: string, fix?: Fix): void {
   if (fix) out.push(`    fix[${fix.kind}]: ${fix.text}`);
 }
 
-// ── portable ps helpers (macOS + Linux) ─────────────────────────────────
+// ── portable process helpers ────────────────────────────────────────────
 
-// OS start time of a process, or null if no such process. Same probe as
-// server.ts's processStartTime — lstart distinguishes a reused PID.
-function processStartTime(pid: number): string | null {
+// OS start time of a process: a string if running, null if no such process,
+// undefined if the probe could not tell. Same probe as server.ts's
+// processStartTime (keep in sync: its output must match the lock file).
+function processStartTime(pid: number): string | null | undefined {
+  const [cmd, args]: [string, string[]] =
+    process.platform === "win32"
+      ? [
+          `${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
+          [
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" -ErrorAction Stop | ForEach-Object { $_.CreationDate.ToFileTimeUtc() })`,
+          ],
+        ]
+      : ["ps", ["-p", String(pid), "-o", "lstart="]];
   try {
     return (
-      execFileSync("ps", ["-p", String(pid), "-o", "lstart="], {
+      execFileSync(cmd, args, {
         encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 5000,
+        windowsHide: true,
       }).trim() || null
     );
-  } catch {
-    return null;
+  } catch (err) {
+    return process.platform !== "win32" &&
+      typeof (err as { status?: unknown }).status === "number"
+      ? null
+      : undefined;
   }
 }
 
+// Parent PID, or null when unknown. Windows has no "reparented to PID 1"
+// notion, so the orphan check below is not implemented there; the server's
+// own parent-death poll (and stdin EOF) is what ends an orphan on Windows.
 function processPpid(pid: number): number | null {
+  if (process.platform === "win32") return null;
   try {
     const n = Number(
       execFileSync("ps", ["-p", String(pid), "-o", "ppid="], {
@@ -200,13 +223,21 @@ function checkServer(): void {
   if (!Number.isFinite(pid) || pid <= 0) {
     report("WARN", "server", `lock file is malformed (${LOCK_FILE})`, {
       kind: "safe",
-      text: `rm ${LOCK_FILE}`,
+      text: `rm ${JSON.stringify(LOCK_FILE)}`,
     });
     return;
   }
   // Alive means: PID exists AND its start time matches what the lock
   // recorded — the same PID-reuse guard as server.ts's acquireSingletonLock.
   const currentStart = processStartTime(pid);
+  if (currentStart === undefined) {
+    report(
+      "WARN",
+      "server",
+      `could not verify whether PID ${pid} is the server (start-time probe failed) — not offering to remove the lock`,
+    );
+    return;
+  }
   const alive =
     currentStart !== null && lockedStart !== "" && currentStart === lockedStart;
   if (!alive) {
@@ -214,7 +245,7 @@ function checkServer(): void {
       "WARN",
       "server",
       `stale lock — PID ${pid} is gone or the PID was reused (the server also self-heals this on next start)`,
-      { kind: "safe", text: `rm ${LOCK_FILE}` },
+      { kind: "safe", text: `rm ${JSON.stringify(LOCK_FILE)}` },
     );
     return;
   }
@@ -226,7 +257,7 @@ function checkServer(): void {
       `orphaned server (pid ${pid}, parent dead) is holding the Baileys session — no new session can connect until it exits`,
       {
         kind: "safe",
-        text: `kill ${pid}   # wait ~5s; if still alive: kill -9 ${pid} && rm ${LOCK_FILE}`,
+        text: `kill ${pid}   # wait ~5s; if still alive: kill -9 ${pid} && rm ${JSON.stringify(LOCK_FILE)}`,
       },
     );
     return;

--- a/server.ts
+++ b/server.ts
@@ -211,8 +211,12 @@ function acquireSingletonLock(): void {
         process.exit(2);
       }
     }
-    if (attempt > 0) {
-      // We removed a stale lock and someone else won the re-create race.
+    if (attempt > 0 || readLock() !== raw) {
+      // Either we already removed a stale lock and someone else won the
+      // re-create race, or the lock changed while we were inspecting it
+      // (another instance took the stale lock over during our probe):
+      // deleting it now would remove a live server's lock. They are the
+      // server; we exit.
       process.stderr.write(
         `${LOG_PREFIX}: lost the lock race to another starting server; exiting\n`,
       );

--- a/server.ts
+++ b/server.ts
@@ -102,41 +102,106 @@ mkdirSync(INBOX_DIR, { recursive: true });
 // making every new instance refuse to start forever. Matching the start time
 // tells a genuine duplicate apart from a reused PID.
 
-// OS start time of a process ("Sat May 16 07:43:46 2026"), or null if no
-// such process. lstart is unique enough to distinguish a reused PID.
-function processStartTime(pid: number): string | null {
+// Command that prints a per-incarnation start time for a PID, or nothing when
+// there is no such process. Windows has no `ps -o lstart`, so ask PowerShell —
+// via CIM, which unlike Get-Process can read the start time of a process the
+// caller does not own (an elevated session's server).
+function startTimeProbe(pid: number): [string, string[]] {
+  return process.platform === "win32"
+    ? [
+        // Absolute path: a bare "powershell.exe" resolves via cwd/PATH.
+        `${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" -ErrorAction Stop | ForEach-Object { $_.CreationDate.ToFileTimeUtc() })`,
+        ],
+      ]
+    : ["ps", ["-p", String(pid), "-o", "lstart="]];
+}
+const PROBE_OPTS = {
+  encoding: "utf8" as const,
+  stdio: ["ignore", "pipe", "ignore"] as ("ignore" | "pipe")[],
+  timeout: 5000,
+  windowsHide: true,
+};
+
+// OS start time of a process ("Sat May 16 07:43:46 2026" / a FILETIME on
+// Windows): a string if it is running, null if there is no such process, and
+// undefined if the probe could not tell (timeout, spawn failure, WMI error).
+// Callers must not read undefined as "dead" — that is how a lock fails open.
+function processStartTime(pid: number): string | null | undefined {
+  const [cmd, args] = startTimeProbe(pid);
   try {
-    return (
-      execFileSync("ps", ["-p", String(pid), "-o", "lstart="], {
-        encoding: "utf8",
-      }).trim() || null
-    );
-  } catch {
-    return null;
+    return execFileSync(cmd, args, PROBE_OPTS).trim() || null;
+  } catch (err) {
+    // ps exits 1 for "no such process"; on Windows a non-zero exit is a real
+    // PowerShell/WMI failure (not-found prints nothing and exits 0).
+    return process.platform !== "win32" &&
+      typeof (err as { status?: unknown }).status === "number"
+      ? null
+      : undefined;
+  }
+}
+
+// Cheap liveness check with no spawn. EPERM = alive but not ours.
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
   }
 }
 
 function acquireSingletonLock(): void {
-  if (existsSync(LOCK_FILE)) {
-    const raw = (() => {
+  let myStart = processStartTime(process.pid);
+  if (myStart === undefined) myStart = processStartTime(process.pid); // one retry
+  if (myStart === undefined) {
+    process.stderr.write(
+      `${LOG_PREFIX}: could not read own start time; lock will be written without one\n`,
+    );
+  }
+  const mine = `${process.pid}\n${myStart ?? ""}\n`;
+  for (let attempt = 0; ; attempt++) {
+    // Atomic create: two instances racing here cannot both succeed.
+    try {
+      writeFileSync(LOCK_FILE, mine, { flag: "wx" });
+      return;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    }
+    // A lock exists. Refuse if its holder is a live server we cannot prove
+    // is a different process; otherwise it is stale — remove it and retry once.
+    const readLock = () => {
       try {
         return readFileSync(LOCK_FILE, "utf8");
       } catch {
         return "";
       }
-    })();
+    };
+    let raw = readLock();
+    if (!raw.trim()) {
+      // Empty: the creator may be between open and write. Give it a moment.
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200);
+      raw = readLock();
+    }
     const [pidLine = "", startLine = ""] = raw.split("\n");
     const otherPid = Number(pidLine.trim());
     const lockedStart = startLine.trim();
     if (Number.isFinite(otherPid) && otherPid > 0 && otherPid !== process.pid) {
-      // Genuine duplicate only if the PID is alive AND started when the lock
-      // recorded. A missing lockedStart is a legacy lock we can't verify —
-      // take over rather than risk a false refusal (the bug this fixes).
       const currentStart = processStartTime(otherPid);
+      const alive =
+        currentStart === undefined ? pidAlive(otherPid) : currentStart !== null;
+      // Genuine duplicate: alive AND (started when the lock recorded, or the
+      // probe could not tell — fail closed rather than double-connect). A
+      // missing lockedStart is a legacy lock we can't verify — take over
+      // rather than risk a false refusal (the bug the start time fixes).
       if (
-        currentStart !== null &&
-        lockedStart &&
-        currentStart === lockedStart
+        alive &&
+        (currentStart === undefined ||
+          (lockedStart !== "" && currentStart === lockedStart))
       ) {
         process.stderr.write(
           `${LOG_PREFIX}: another whatsapp server is already running (pid ${otherPid}). ` +
@@ -146,11 +211,15 @@ function acquireSingletonLock(): void {
         process.exit(2);
       }
     }
+    if (attempt > 0) {
+      // We removed a stale lock and someone else won the re-create race.
+      process.stderr.write(
+        `${LOG_PREFIX}: lost the lock race to another starting server; exiting\n`,
+      );
+      process.exit(2);
+    }
+    rmSync(LOCK_FILE, { force: true });
   }
-  writeFileSync(
-    LOCK_FILE,
-    `${process.pid}\n${processStartTime(process.pid) ?? ""}\n`,
-  );
 }
 
 function releaseSingletonLock(): void {
@@ -1684,12 +1753,29 @@ process.on("SIGINT", shutdown);
 // start). Poll the parent by PID + start time — start time, not bare PID,
 // because a reused PID would otherwise masquerade as a live parent. Two
 // consecutive misses required so a transient ps failure can't kill us.
+// Windows: a PowerShell spawn costs ~1.5 s of CPU, far too much for a 15 s
+// tick, so use a signal-0 liveness check there instead. Known ceiling: a
+// PID reused within one tick would mask a dead parent; hold a handle
+// (Wait-Process) if that ever bites.
 const PARENT_PID = process.ppid;
-const PARENT_START = processStartTime(PARENT_PID);
+let PARENT_START =
+  process.platform === "win32" ? undefined : processStartTime(PARENT_PID);
 let parentMisses = 0;
 setInterval(() => {
-  if (PARENT_START === null) return;
-  if (processStartTime(PARENT_PID) === PARENT_START) {
+  if (PARENT_START === null) return; // parent already gone at startup
+  let gone: boolean;
+  if (process.platform === "win32") {
+    gone = !pidAlive(PARENT_PID);
+  } else {
+    const now = processStartTime(PARENT_PID);
+    if (now === undefined) return; // probe failed: no evidence either way
+    if (PARENT_START === undefined) {
+      PARENT_START = now; // startup probe failed: arm from the first good one
+      return;
+    }
+    gone = now !== PARENT_START;
+  }
+  if (!gone) {
     parentMisses = 0;
     return;
   }


### PR DESCRIPTION
## What & why

On Windows the singleton lock has never worked. `processStartTime()` shells out to `ps -p <pid> -o lstart=`, which does not exist there (Git for Windows `ps` has no `-o` and cannot see native processes), so it always returned `null` and:

- `acquireSingletonLock` treated every existing lock as unverifiable and took it over. Two Claude Code sessions (two terminals, or a restart racing a session that is still closing) each start a server on the same linked-device auth and kick each other off Baileys with `440 session conflict`, forever. That is the "replies stopped" symptom.
- The parent-death poll never armed (`PARENT_START === null`), so a hard-killed session left an orphaned server holding the lock and the socket.
- `scripts/doctor.ts` uses the same probe, so on Windows it reported a live lock as **stale** and offered `rm .server.lock` as a `fix[safe]`.

**Change**

- **Probe:** on win32 ask PowerShell (absolute path, `-NoProfile -NonInteractive`, `windowsHide`, 5 s timeout) for the process creation time via `Get-CimInstance Win32_Process`; unlike `Get-Process`, CIM can read a process the caller does not own (an elevated session's server). The result is tri-state: start string / `null` = no such process / `undefined` = the probe could not tell (timeout, spawn failure, WMI error). `undefined` is never read as "dead".
- **Lock acquire** is now an atomic exclusive create (`writeFileSync(..., { flag: "wx" })`). On `EEXIST` the holder is inspected: alive **and** (start time matches the lock, **or** the probe could not tell) → refuse with exit 2 (fail closed rather than double-connect); otherwise stale (dead PID, reused PID) → remove and retry once. A legacy lock with no start line and a live PID is still taken over, as before. Before removing a stale lock the file is re-read; if its content no longer matches what was inspected, another instance took the stale lock over during our probe and we exit 2 instead of deleting a live server's lock (review follow-up, see check 6b).
- **Parent poll:** unchanged on POSIX except that an unknown probe is not a miss and `PARENT_START` arms late if the startup probe failed. On win32 a PowerShell spawn costs ~1.5 s of CPU (measured), far too much for a 15 s tick, so the poll uses `process.kill(ppid, 0)` there. Known ceiling: a PID reused within one tick would mask a dead parent (a `Wait-Process` handle is the upgrade if that ever bites).
- **doctor.ts:** same probe; an unknown result reports "could not verify" and does not offer `rm`; `fix[safe]` paths are quoted so Git Bash keeps the backslashes; the `ppid === 1` orphan check is not implemented on Windows and the comment now says so.

**Sensitive area: the singleton lock.** Invariant preserved: a genuine duplicate (holder alive and its start time matches the lock) refuses to start with exit code 2 while the first stays connected; a stale or legacy lock is taken over; two instances racing cannot both acquire (new, `wx`), including when a stale lock is already on disk (new, re-read before `rmSync`). Non-Windows: the `ps` probe is unchanged; the acquire is atomic instead of check-then-write; the poll gains "unknown ≠ miss".

Scope note: this PR is the lock fix only. The session-start notice that tells a second session another one holds the connection is moving to a follow-up PR together with support for other MCP clients (Codex, Gemini, Cursor), where it can suppress the case of the session's own server holding the lock.

Startup cost on Windows: one CIM probe (two if a lock exists), ~0.5–1.5 s each, before the MCP handshake. No PowerShell spawn after startup.

## How I tested it

Windows 11 (10.0.26200) · Bun 1.3.14 · isolated `WHATSAPP_STATE_DIR`, no phone number, no pairing. The lock is acquired at module load, before MCP/WhatsApp start, so none of this needs a connection. Each server was started as a child process with stdin held open; only test-spawned PIDs were ever stopped. Full log below.

| # | Check | Result |
|---|---|---|
| 1a | second server refused with exit 2, naming the live pid | PASS |
| 1b | lock line 2 == OS start time of the holder (to the µs) | PASS |
| 2a | lock released on clean shutdown | PASS |
| 2b–2g | dead-pid / reused-pid (live unrelated process, wrong start) / legacy pid-only / garbage / empty / negative-pid locks all taken over | PASS |
| 2h–2i | PowerShell-injection-shaped pid line (`1; New-Item canary…`): server starts, canary never created | PASS |
| 3 | parent killed while stdin stays open (console-inherited child): no false positive for 45 s, then "parent process gone" and exit in ~28 s, lock released | PASS |
| 4a | probe forced to fail (bogus PowerShell path) + **live** holder → refused (fail closed) | PASS |
| 4b | probe forced to fail + **dead** holder → taken over, empty start line, warning logged | PASS |
| 4c | doctor with the probe failing on a live pid → "could not verify", no `rm` offered | PASS |
| 5a/5b | doctor: live lock PASS; stale lock WARN with quoted `rm` fix | PASS |
| 6 | two servers started in the same instant, 3 trials → exactly one survives each time | PASS |
| 6b | stale lock already on disk, two servers started in the same instant, 5 trials → exactly one survives each time (before the guard: both survived in 5 of 5) | PASS |
| 7 | stdin EOF → shutdown in ~100 ms, lock released | PASS |

Also: `tsc --noEmit --strict` clean, `prettier --check` clean. The full harness was re-run after the review fix (2026-08-19 10:17); the log below is that run. Not exercised: two real Claude Code sessions through the MCP launcher (same code path as 1a), and a paired WhatsApp connection under the lock (irrelevant to lock code, which runs before `connectWhatsApp()`).

<details>
<summary>Full test log (driver script + per-check output)</summary>

### windows-singleton-lock: manual test log (Windows)

Date: 2026-08-19 10:17 · Windows 10.0.26200.0 · Bun 1.3.14 · tree as committed here (working tree at test time; the only later change is comment wording) · driver: this file's sibling `run.ps1`
State dir isolated via `WHATSAPP_STATE_DIR`; no phone number, no pairing. The lock is acquired at module load, before MCP/WhatsApp start, so nothing here needs a connection. Live bridge PIDs before: 12876, 29648 (never touched).

#### 1. Duplicate server is refused; lock records the real OS start time
Started A (pid 17668) at 10:17:08.427. Lock file: `17668 ⏎ 134315722203427790 ⏎`. OS says A's StartTime.ToFileTimeUtc() = `134315722203427793`.
Started B (pid 28736) → exited=True exit code=2. B stderr:
```
whatsapp channel: another whatsapp server is already running (pid 17668). Refusing to start — duplicate instances kick each other off Baileys. Lock file: <repo>\.pipeline\windows-lock-test\state\.server.lock
```
**PASS** duplicate refused · **PASS** lock start time matches OS

#### 5. doctor.ts on Windows: live lock, then stale lock
With A (pid 17668) alive:
```
[INFO] env: plugin v0.14.1, bun 1.3.14, win32, state dir: <repo>\.pipeline\windows-lock-test\state
[PASS] state-dir: <repo>\.pipeline\windows-lock-test\state exists and is writable
[PASS] server: server running (pid 17668) — note: it may belong to another Claude Code session on this machine
[INFO] access-config: access.json absent — the server creates defaults (dmPolicy: pairing) on next start
SUMMARY: 1 error, 0 warn, 5 info, 2 pass

```
Closed A's stdin at 10:17:12.503 → A exited=True; lock file after: `(no lock file)` (release on clean shutdown = True).
With a stale lock (pid 999999):
```
[INFO] env: plugin v0.14.1, bun 1.3.14, win32, state dir: <repo>\.pipeline\windows-lock-test\state
[PASS] state-dir: <repo>\.pipeline\windows-lock-test\state exists and is writable
[WARN] server: stale lock — PID 999999 is gone or the PID was reused (the server also self-heals this on next start)
    fix[safe]: rm "<repo>\\.pipeline\\windows-lock-test\\state\\.server.lock"
[INFO] access-config: access.json absent — the server creates defaults (dmPolicy: pairing) on next start
SUMMARY: 1 error, 1 warn, 5 info, 1 pass

```
**PASS** live · **PASS** stale · **PASS** lock released on stop

#### 2. Lock takeover: stale, reused-PID, legacy, garbage, empty, negative, and an injection attempt
- dead pid, any start time → wrote `999999 ⏎ 123`; server pid 28164 alive=True, lock now `28164 ⏎ 134315722331572520 ⏎` → **PASS**
- live explorer.exe pid 11516, wrong start time (reused-PID case) → wrote `11516 ⏎ 123`; server pid 29456 alive=True, lock now `29456 ⏎ 134315722422296570 ⏎` → **PASS**
- legacy lock: pid only, no start line (pre-0.14 format) → wrote `11516`; server pid 13368 alive=True, lock now `13368 ⏎ 134315722513084520 ⏎` → **PASS**
- garbage → wrote `not-a-pid ⏎ garbage`; server pid 9012 alive=True, lock now `9012 ⏎ 134315722603713470 ⏎` → **PASS**
- empty file → wrote ``; server pid 23064 alive=True, lock now `23064 ⏎ 134315722694385140 ⏎` → **PASS**
- negative pid → wrote `-5 ⏎ 123`; server pid 17292 alive=True, lock now `17292 ⏎ 134315722784941450 ⏎` → **PASS**
- PowerShell injection attempt in the pid line → wrote `1; New-Item -ItemType File -Path '<repo>\.pipeline\windows-lock-test\CANARY-INJECTION-RAN.txt' | Out-Null; 1 ⏎ 123`; server pid 2708 alive=True, lock now `2708 ⏎ 134315722875818050 ⏎` → **PASS**
- injection canary file `CANARY-INJECTION-RAN.txt` exists after that run: False → **PASS** (a hit here would mean the pid was interpolated unsanitised into `-Command`)

#### 6. Race: two servers started in the same instant (3 trials)
Acquire is an atomic exclusive create (`wx`); a loser inspects the winner's lock and exits 2. Three back-to-back double starts:
- trial 1 → X(pid 23300) alive=False, Y(pid 22820) alive=True, lock `22820 ⏎ 134315722966657810 ⏎`
- trial 2 → X(pid 15032) alive=True, Y(pid 29208) alive=False, lock `15032 ⏎ 134315723077451420 ⏎`
- trial 3 → X(pid 24180) alive=True, Y(pid 28008) alive=False, lock `24180 ⏎ 134315723188179470 ⏎`
Both survived in 0/3 trials → **PASS** (acquire is an atomic exclusive create, so two racers cannot both succeed)

#### 6b. Race: stale lock already on disk, two servers started in the same instant (5 trials)
Reviewer's scenario: A finds the stale lock, probes, removes it, creates its own; B (a probe-duration behind) still holds the *stale* content it read, removes A's fresh lock and creates its own → both survive. Guard: re-read the lock immediately before `rmSync` and exit 2 if it no longer matches what was inspected.
- trial 1 → X(pid 4520) alive=False, Y(pid 5900) alive=True, lock `5900 ⏎ 134315723299174620 ⏎`; loser stderr: `another whatsapp server is already running (pid 5900). Refusing to start — duplicate instances kick each other off Baileys. Lock file: <repo>\.pipeline\windows-lock-test\state\.server.lock`
- trial 2 → X(pid 13392) alive=True, Y(pid 7136) alive=False, lock `13392 ⏎ 134315723433988930 ⏎`; loser stderr: `lost the lock race to another starting server; exiting`
- trial 3 → X(pid 12596) alive=False, Y(pid 25148) alive=True, lock `25148 ⏎ 134315723568039320 ⏎`; loser stderr: `lost the lock race to another starting server; exiting`
- trial 4 → X(pid 22960) alive=True, Y(pid 25464) alive=False, lock `22960 ⏎ 134315723702065720 ⏎`; loser stderr: `lost the lock race to another starting server; exiting`
- trial 5 → X(pid 28168) alive=True, Y(pid 21052) alive=False, lock `28168 ⏎ 134315723835909620 ⏎`; loser stderr: `lost the lock race to another starting server; exiting`
Both survived in 0/5 trials → **PASS**

#### 4. When the start-time probe cannot answer, a live holder is refused and a dead one is still taken over
Harness: copies of server.ts / doctor.ts with the PowerShell path pointed at a non-existent exe, so every probe fails with ENOENT → result *unknown*. The server must then fall back to a signal-0 liveness check: live PID → refuse (fail closed), dead PID → take over. Startup probe untouched otherwise.
- lock = live explorer pid 11516 / wrong start, probe broken → exited=True code=2 → **PASS** (must refuse: alive + unverifiable)
```
whatsapp channel: could not read own start time; lock will be written without one
whatsapp channel: another whatsapp server is already running (pid 11516). Refusing to start — duplicate instances kick each other off Baileys. Lock file: <repo>\.pipeline\windows-lock-test\state\.server.lock
```
- lock = dead pid 999999, probe broken → alive=True, lock now `29680 ⏎  ⏎` (empty start line + warning expected) → **PASS**
```
whatsapp channel: could not read own start time; lock will be written without one
whatsapp channel: starting
whatsapp channel: using WA Web version 2.3000.1043857760 (fetched)
  or run /whatsapp-claude-channel:configure <phone> for reliable pairing.
  Set WHATSAPP_PHONE_NUMBER in ~/.whatsapp-channel/.env
whatsapp channel: no phone number configured for pairing code fallback.
```
- doctor with the probe broken and a lock naming a live pid:
```
[WARN] server: could not verify whether PID 11516 is the server (start-time probe failed) — not offering to remove the lock
[INFO] access-config: access.json absent — the server creates defaults (dmPolicy: pairing) on next start

```
  → **PASS** (WARN 'could not verify', no rm offered)

#### 3. Orphan detection: parent killed while stdin stays open → exit via the poll, no false positive first
Parent cmd.exe pid 24956 → child bun pid 29296 (stderr goes straight to a file bun owns). The child inherits the parent's *console*, so its stdin does NOT close when the parent dies; only the parent poll (signal-0 liveness on Windows) can notice.
Waiting 45 s with the parent alive (three polls; no false positive expected)…
At 10:20:59.667: bun alive=True · 'parent process gone' logged so far=False
Killing ONLY the parent: `taskkill /PID 24956 /F` (no /T) at 10:20:59.669…
bun exited=True after ~26 s. orphan stderr (whatsapp lines):
```
whatsapp channel: starting
whatsapp channel: using WA Web version 2.3000.1043857760 (fetched)
whatsapp channel: no phone number configured for pairing code fallback.
whatsapp channel: parent process gone; shutting down orphaned server
whatsapp channel: shutting down
whatsapp channel: disconnected (reason: unknown)
whatsapp channel: reconnecting in 1s
```
Lock file after: `(no lock file)`
**PASS**

#### 7. Normal exit path: stdin EOF → immediate shutdown, lock released
Closed stdin at 10:21:34.707 → exited=True in ~36 ms, lock after: `(no lock file)`. stderr:
```
whatsapp channel: starting
whatsapp channel: using WA Web version 2.3000.1043857760 (fetched)
whatsapp channel: no phone number configured for pairing code fallback.
  or run /whatsapp-claude-channel:configure <phone> for reliable pairing.
  Set WHATSAPP_PHONE_NUMBER in ~/.whatsapp-channel/.env
whatsapp channel: shutting down
whatsapp channel: disconnected (reason: unknown)
whatsapp channel: reconnecting in 1s
```
**PASS**

#### Summary
| Check | Result |
|---|---|
| 1a duplicate refused with exit 2 naming the live pid | PASS |
| 1b lock line 2 == OS start time of the lock holder (to the microsecond) | PASS |
| 5a doctor: live lock reported PASS, no ppid/orphan noise | PASS |
| 5b doctor: stale lock detected | PASS |
| 2a lock released on clean shutdown | PASS |
| 2b dead-pid lock taken over | PASS |
| 2c reused-pid (live unrelated process, wrong start time) taken over | PASS |
| 2d legacy pid-only lock taken over | PASS |
| 2e garbage lock taken over | PASS |
| 2f empty lock taken over | PASS |
| 2g negative-pid lock taken over | PASS |
| 2h injection-shaped lock: server still starts | PASS |
| 2i injection-shaped lock: payload did NOT execute (canary absent) | PASS |
| 6 simultaneous double start: exactly one survives (3/3 trials) | PASS |
| 6b stale lock + simultaneous double start: exactly one survives (5/5 trials) | PASS |
| 4a probe unknown + live pid → refused (fail closed) | PASS |
| 4b probe unknown + dead pid → taken over, empty start line, warning logged | PASS |
| 4c doctor: probe unknown → 'could not verify', no rm fix offered | PASS |
| 3 orphan: no false positive for 45 s, exit within ~30 s of parent death, lock released | PASS |
| 7 stdin EOF still shuts down promptly and releases the lock | PASS |

Live bridge PIDs after: 12876, 29648, all pre-existing PIDs still alive: True
Stray test processes after cleanup: 0

VERDICT: SHIP
Done 10:21:35.147.

</details>

## Checklist

- [x] `prettier --check` passes; `trunk` is not installed on this machine, relying on CI for `trunk check`.
- [x] **Version bumped in BOTH files to the same new version** (patch = fix): `0.14.0` → `0.14.1`
  - [x] `.claude-plugin/plugin.json` → `version`
  - [x] `.claude-plugin/marketplace.json` → `plugins[0].version`
- [x] No new runtime dependencies.
- [x] No runtime state / secrets committed.
- [x] Touches the **singleton lock**; invariant described above.
- [x] Review follow-up (stale-lock takeover race) closed and covered by check 6b.

