### PR TITLE
feat(tools): let clients that cannot be pushed to find out anyway

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "whatsapp-claude-channel",
       "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control, pairing, allowlists, and group policy.",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "source": "./",
       "category": "channels"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "whatsapp-claude-channel",
   "displayName": "WhatsApp Channel for Claude Code",
   "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /whatsapp-claude-channel:access.",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "author": {
     "name": "Rich627"
   },

--- a/USAGE.md
+++ b/USAGE.md
@@ -207,7 +207,7 @@ pkill -f "whatsapp.*server"
 
 ## Known limitations
 
-**Inbound message delivery may not work.** Claude Code's channel notification system (`notifications/claude/channel`) has a confirmed client-side bug where inbound messages sent by the MCP server are silently dropped and never appear in the conversation. This affects all channel plugins (WhatsApp, Telegram, etc.) and is tracked across multiple issues ([#37933](https://github.com/anthropics/claude-code/issues/37933), [#36477](https://github.com/anthropics/claude-code/issues/36477), [#37633](https://github.com/anthropics/claude-code/issues/37633)). The server-side implementation is correct — the fix must come from the Claude Code client. No reliable workaround exists as of v2.1.83.
+**Inbound message delivery is Claude Code only.** Messages are pushed into a session with `notifications/claude/channel`, which is a Claude Code extension, not part of MCP. Other MCP clients (Codex CLI, Gemini CLI, Cursor) drop unknown notifications silently, so there the plugin is poll-only: call `catch_up` or `unreplied` to see what arrived. Delivery inside Claude Code was broken by client bugs ([#37933](https://github.com/anthropics/claude-code/issues/37933), [#36477](https://github.com/anthropics/claude-code/issues/36477), [#37633](https://github.com/anthropics/claude-code/issues/37633)) and worked again when last checked on v2.1.235; if messages stop appearing, check those issues before suspecting this plugin.
 
 ## Resetting auth
 

--- a/scripts/doctor.test.ts
+++ b/scripts/doctor.test.ts
@@ -21,9 +21,21 @@ function freshStateDir(): string {
 
 // lstart of a live pid, exactly as doctor computes it
 function lstart(pid: number): string {
-  return execFileSync("ps", ["-p", String(pid), "-o", "lstart="], {
-    encoding: "utf8",
-  }).trim();
+  // Same probe doctor uses. `ps -o lstart=` does not exist on Windows, so this
+  // helper has to branch too or every live-lock test is red there.
+  const [cmd, args] =
+    process.platform === "win32"
+      ? [
+          `${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
+          [
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" -ErrorAction Stop | ForEach-Object { $_.CreationDate.ToFileTimeUtc() })`,
+          ],
+        ]
+      : ["ps", ["-p", String(pid), "-o", "lstart="]];
+  return execFileSync(cmd, args, { encoding: "utf8" }).trim();
 }
 
 describe("state-dir", () => {

--- a/scripts/doctor.ts
+++ b/scripts/doctor.ts
@@ -217,7 +217,7 @@ function checkServer(): void {
   } catch {
     /* fall through to malformed */
   }
-  const [pidLine = "", startLine = ""] = raw.split("\n");
+  const [pidLine = "", startLine = "", clientLine = ""] = raw.split("\n");
   const pid = Number(pidLine.trim());
   const lockedStart = startLine.trim();
   if (!Number.isFinite(pid) || pid <= 0) {
@@ -262,11 +262,17 @@ function checkServer(): void {
     );
     return;
   }
-  report(
-    "PASS",
-    "server",
-    `server running (pid ${pid}) — note: it may belong to another Claude Code session on this machine`,
-  );
+  // Line 3 of the lock is the client that started the holder, so this can name
+  // the owner instead of hedging. Absent on locks written before 0.15.0, and
+  // on servers started by a client that does not identify itself.
+  const client = clientLine.trim();
+  const owner =
+    client === ""
+      ? " — started by a client that does not identify itself, or before 0.15.0"
+      : client === (process.env.CLAUDE_PID ?? "").trim()
+        ? " — started by this session"
+        : ` — started by another session or client (pid ${client})`;
+  report("PASS", "server", `server running (pid ${pid})${owner}`);
 }
 
 const VALID_POLICIES = ["pairing", "allowlist", "disabled"];

--- a/server.ts
+++ b/server.ts
@@ -15,6 +15,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
+  type CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import makeWASocket, {
@@ -1022,6 +1023,41 @@ function markReplied(chat_id: string): void {
   }
 }
 
+// Clients other than Claude Code cannot be pushed to: MCP has no standard
+// server-to-client channel that reaches the model, and unknown notification
+// methods are dropped silently. So the agent asks, and this parks that ask
+// until a message lands.
+//
+// ponytail: re-reads the log every 2s while waiting, rather than being woken
+// in-process. Simpler, works whoever wrote the line, and costs at most 2s of
+// latency in a chat bridge. Wake on write if that ever matters.
+async function waitForUnreplied(maxMs: number): Promise<MessageLogEntry[]> {
+  const deadline = Date.now() + maxMs;
+  for (;;) {
+    const pending = getUnreplied();
+    if (pending.length > 0) return pending;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return [];
+    await new Promise((resolve) => {
+      const timer = setTimeout(resolve, Math.min(2000, remaining));
+      timer.unref?.();
+    });
+  }
+}
+
+function formatMessages(entries: MessageLogEntry[]): string {
+  return entries
+    .map((m) => {
+      const parts = [`[${m.ts}] ${m.user} in ${m.group_name ?? m.chat_id}:`];
+      if (m.text) parts.push(m.text);
+      if (m.image_path) parts.push(`(image: ${m.image_path})`);
+      if (m.attachment_kind) parts.push(`(${m.attachment_kind} attachment)`);
+      parts.push(`  chat_id=${m.chat_id} message_id=${m.id}`);
+      return parts.join("\n");
+    })
+    .join("\n\n");
+}
+
 function getUnreplied(): MessageLogEntry[] {
   try {
     if (!existsSync(MESSAGE_LOG)) return [];
@@ -1366,6 +1402,12 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: "wait_for_messages",
+      description:
+        "Wait for the next inbound WhatsApp message, up to 40 seconds. Returns immediately if messages are already unreplied. Use this when you want to stay responsive without polling: call it, handle whatever it returns, call it again. It returns an empty result if nothing arrives in time, which is normal, not an error. (In Claude Code messages are also pushed into the session automatically, so this is mainly for other MCP clients.)",
+      inputSchema: { type: "object", properties: {} },
+    },
+    {
       name: "unreplied",
       description:
         "Get messages received but not yet replied to. Call this on session start (after status) to catch up on messages that arrived before this session or were missed due to a restart. Each entry includes chat_id, message_id, user, text, and timestamp.",
@@ -1401,7 +1443,12 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
   ],
 }));
 
-mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+// Wrapped below so every result carries the unreplied count: a client that
+// cannot be pushed to still learns there is traffic, on its next tool call,
+// whatever that call was.
+const handleToolCall = async (req: {
+  params: { name: string; arguments?: unknown };
+}): Promise<CallToolResult> => {
   const args = (req.params.arguments ?? {}) as Record<string, unknown>;
   try {
     switch (req.params.name) {
@@ -1664,6 +1711,18 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         return { content: [{ type: "text", text: lines.join("\n") }] };
       }
 
+      case "wait_for_messages": {
+        // 40s, not longer: the reference SDK's default client timeout is 60s
+        // and resetTimeoutOnProgress is off by default, so an over-long wait is
+        // cancelled client-side rather than answered. The margin covers the
+        // re-check tick and any client configured tighter than the default.
+        const arrived = await waitForUnreplied(40_000);
+        const text = arrived.length
+          ? `${arrived.length} unreplied message(s):\n\n${formatMessages(arrived)}`
+          : "No new messages in the last 40 seconds. Call again to keep waiting.";
+        return { content: [{ type: "text", text }] };
+      }
+
       case "unreplied": {
         const filterChat = args.chat_id as string | undefined;
         let unreplied = getUnreplied();
@@ -1674,19 +1733,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
             content: [{ type: "text", text: "No unreplied messages." }],
           };
         }
-        const summary = unreplied
-          .map((m) => {
-            const parts = [
-              `[${m.ts}] ${m.user} in ${m.group_name ?? m.chat_id}:`,
-            ];
-            if (m.text) parts.push(m.text);
-            if (m.image_path) parts.push(`(image: ${m.image_path})`);
-            if (m.attachment_kind)
-              parts.push(`(${m.attachment_kind} attachment)`);
-            parts.push(`  chat_id=${m.chat_id} message_id=${m.id}`);
-            return parts.join("\n");
-          })
-          .join("\n\n");
+        const summary = formatMessages(unreplied);
         return {
           content: [
             {
@@ -1775,6 +1822,16 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       isError: true,
     };
   }
+};
+
+mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const result = await handleToolCall(req);
+  const pending = getUnreplied().length;
+  const last = result.content?.[result.content.length - 1];
+  if (pending > 0 && last?.type === "text" && req.params.name !== "unreplied") {
+    last.text += `\n\n[${pending} unreplied WhatsApp message(s) waiting — call unreplied or wait_for_messages]`;
+  }
+  return result;
 });
 
 // ─── MCP transport ─────────────────────────────────────────────────────

--- a/server.ts
+++ b/server.ts
@@ -82,6 +82,10 @@ try {
 
 const PHONE_NUMBER = process.env.WHATSAPP_PHONE_NUMBER;
 const STATIC = process.env.WHATSAPP_ACCESS_MODE === "static";
+// The client process that spawned us, when it identifies itself. Claude Code
+// sets CLAUDE_PID; other MCP clients set nothing, which reads as "unknown"
+// and is reported as such rather than guessed at.
+const CLIENT_ID = (process.env.CLAUDE_PID ?? "").trim();
 const ACCOUNT_NAME = process.env.WHATSAPP_ACCOUNT_NAME || "";
 const SERVER_NAME = ACCOUNT_NAME ? `whatsapp-${ACCOUNT_NAME}` : "whatsapp";
 const LOG_PREFIX = ACCOUNT_NAME
@@ -155,7 +159,11 @@ function pidAlive(pid: number): boolean {
   }
 }
 
-function acquireSingletonLock(): void {
+// Who holds the connection when we cannot. `client` is the CLAUDE_PID the
+// holder recorded, "" when started by something that does not set one.
+type LockHolder = { pid: number; client: string };
+
+function acquireSingletonLock(): LockHolder | null {
   let myStart = processStartTime(process.pid);
   if (myStart === undefined) myStart = processStartTime(process.pid); // one retry
   if (myStart === undefined) {
@@ -163,12 +171,16 @@ function acquireSingletonLock(): void {
       `${LOG_PREFIX}: could not read own start time; lock will be written without one\n`,
     );
   }
-  const mine = `${process.pid}\n${myStart ?? ""}\n`;
+  // Line 3 is the client that spawned us, so a refused server and doctor can
+  // name WHOSE connection this is with a string compare instead of a process
+  // query (under Git Bash on Windows a hook's own $PPID is 1, so ancestry is
+  // not available there at all).
+  const mine = `${process.pid}\n${myStart ?? ""}\n${CLIENT_ID}\n`;
   for (let attempt = 0; ; attempt++) {
     // Atomic create: two instances racing here cannot both succeed.
     try {
       writeFileSync(LOCK_FILE, mine, { flag: "wx" });
-      return;
+      return null;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
     }
@@ -187,9 +199,10 @@ function acquireSingletonLock(): void {
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200);
       raw = readLock();
     }
-    const [pidLine = "", startLine = ""] = raw.split("\n");
+    const [pidLine = "", startLine = "", clientLine = ""] = raw.split("\n");
     const otherPid = Number(pidLine.trim());
     const lockedStart = startLine.trim();
+    const otherClient = clientLine.trim();
     if (Number.isFinite(otherPid) && otherPid > 0 && otherPid !== process.pid) {
       const currentStart = processStartTime(otherPid);
       const alive =
@@ -205,10 +218,10 @@ function acquireSingletonLock(): void {
       ) {
         process.stderr.write(
           `${LOG_PREFIX}: another whatsapp server is already running (pid ${otherPid}). ` +
-            `Refusing to start — duplicate instances kick each other off Baileys. ` +
+            `Not connecting — duplicate instances kick each other off Baileys. ` +
             `Lock file: ${LOCK_FILE}\n`,
         );
-        process.exit(2);
+        return { pid: otherPid, client: otherClient };
       }
     }
     if (attempt > 0 || readLock() !== raw) {
@@ -216,24 +229,38 @@ function acquireSingletonLock(): void {
       // re-create race, or the lock changed while we were inspecting it
       // (another instance took the stale lock over during our probe):
       // deleting it now would remove a live server's lock. They are the
-      // server; we exit.
+      // server; we go into conflict mode.
       process.stderr.write(
-        `${LOG_PREFIX}: lost the lock race to another starting server; exiting\n`,
+        `${LOG_PREFIX}: lost the lock race to another starting server\n`,
       );
-      process.exit(2);
+      return { pid: otherPid > 0 ? otherPid : 0, client: otherClient };
     }
     rmSync(LOCK_FILE, { force: true });
   }
 }
 
 function releaseSingletonLock(): void {
+  if (CONFLICT) return; // not ours to release
   try {
     const pidLine = readFileSync(LOCK_FILE, "utf8").split("\n")[0].trim();
     if (Number(pidLine) === process.pid) rmSync(LOCK_FILE, { force: true });
   } catch {}
 }
 
-acquireSingletonLock();
+// Null when we hold the connection. Set when another server has it: we stay
+// up in conflict mode, serve one tool that says so, and never touch Baileys —
+// the invariant is one connection, not one process. Exiting instead would be
+// invisible; no MCP client tells the user why a server died.
+const CONFLICT = acquireSingletonLock();
+const conflictReason = CONFLICT
+  ? `Another WhatsApp server already holds this account's connection (pid ${CONFLICT.pid}${
+      CONFLICT.client
+        ? CONFLICT.client === CLIENT_ID
+          ? ", started by this same client"
+          : `, started by another client (pid ${CONFLICT.client})`
+        : ""
+    }). WhatsApp allows one connection per account, so this session cannot send or receive. To use WhatsApp here, quit the other session, then start this one again.`
+  : "";
 
 process.on("unhandledRejection", (err) => {
   process.stderr.write(`${LOG_PREFIX}: unhandled rejection: ${err}\n`);
@@ -1103,6 +1130,15 @@ const mcp = new Server(
       },
     },
     instructions: [
+      // Conflict first: instructions are one of the few things every MCP
+      // client must put in front of the model, so this is where a refused
+      // server gets to explain itself.
+      ...(CONFLICT
+        ? [
+            `WHATSAPP UNAVAILABLE IN THIS SESSION. ${conflictReason} Tell the user this if they ask about WhatsApp; do not attempt to send messages.`,
+            "",
+          ]
+        : []),
       ...(ACCOUNT_NAME
         ? [
             `This is the "${ACCOUNT_NAME}" WhatsApp account. Messages from this account include account="${ACCOUNT_NAME}" in the meta. When multiple WhatsApp accounts are connected, use the correct account\'s tools to reply — check the channel source or account field to determine which account received the message.`,
@@ -1141,6 +1177,19 @@ const mcp = new Server(
 // Permission relay — forward to all allowlisted DMs.
 // Track permission request message IDs for emoji-based approval
 const permissionMessageMap = new Map<string, string>(); // messageId → requestId
+
+// Was this request id one we asked about and are still waiting on? Claims it
+// if so, so a repeated reply is treated as ordinary chat.
+function claimPermission(requestId: string): boolean {
+  let found = false;
+  for (const [messageId, id] of permissionMessageMap) {
+    if (id === requestId) {
+      permissionMessageMap.delete(messageId);
+      found = true;
+    }
+  }
+  return found;
+}
 
 function formatPermissionPreview(
   tool_name: string,
@@ -2086,9 +2135,13 @@ async function handleMessage(msg: WAMessage): Promise<void> {
   // Ensure group config directory exists
   if (isGroup) ensureGroupDir(remoteJid);
 
-  // Permission reply intercept
+  // Permission reply intercept, only while that request id is outstanding:
+  // the pattern ("yes" + 5 letters) is reachable by ordinary chat, and
+  // swallowing a real message — sender sees a tick, agent never sees the
+  // text — is worse than missing an approval. On clients that never send
+  // permission requests, nothing is listening at all.
   const permMatch = PERMISSION_REPLY_RE.exec(text);
-  if (permMatch) {
+  if (permMatch && claimPermission(permMatch[2]!.toLowerCase())) {
     void mcp.notification({
       method: "notifications/claude/channel/permission",
       params: {
@@ -2622,5 +2675,26 @@ async function connectWhatsApp(): Promise<void> {
   );
 }
 
-process.stderr.write(`${LOG_PREFIX}: starting\n`);
-await connectWhatsApp();
+if (CONFLICT) {
+  // Registered last, so these replace the real handlers. Exposing reply/react
+  // in conflict mode would be worse than exposing nothing: they would accept a
+  // message, fail to send it, and the agent would report it as delivered.
+  mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: "whatsapp_unavailable",
+        description: `WhatsApp is not available in this session. ${conflictReason} No other WhatsApp tool exists here.`,
+        inputSchema: { type: "object", properties: {} },
+      },
+    ],
+  }));
+  mcp.setRequestHandler(CallToolRequestSchema, async () => ({
+    content: [{ type: "text", text: conflictReason }],
+  }));
+  // Baileys is never touched here, so the one-connection invariant holds
+  // exactly as it did when this path called process.exit(2).
+  process.stderr.write(`${LOG_PREFIX}: ${conflictReason}\n`);
+} else {
+  process.stderr.write(`${LOG_PREFIX}: starting\n`);
+  await connectWhatsApp();
+}


### PR DESCRIPTION
> **Stacked on #14.** GitHub cannot target a branch on my fork, so this PR shows both commits. Only the second one, `ea91d40`, is new here; `8fa85e4` is #14 under review. I will rebase onto main once #14 lands, and this can wait until then.

## What & why

Inbound messages reach a session through `notifications/claude/channel`, a Claude Code extension. I went looking for the standard equivalent and there isn't one:

- Every standard server-to-client message is either request-scoped (`notifications/progress`, and in the current spec `notifications/message` too) or subscription-gated (`resources/updated`, which needs the client to have called `resources/subscribe` first). None is defined as putting text in front of the model; resources are explicitly "application-driven, with host applications determining how to incorporate context".
- Unknown notification methods are dropped with no error and no delivery signal. JSON-RPC forbids responding to a notification, and the reference SDK's `_onnotification` returns early when no handler is registered, so a server cannot even tell that delivery failed.
- The 2026-07-28 spec deprecates sampling and logging and states the server **MUST NOT** send notification types the client has not explicitly requested.
- `sampling/createMessage` cannot help even in principle: its result returns to the server, not into the user's conversation.

So on Codex CLI, Gemini CLI or Cursor, a WhatsApp message today arrives, passes the access gate, gets logged, and nobody ever mentions it. This adds the two mechanisms that need no capability negotiation and therefore work on any client.

**`wait_for_messages`** returns unreplied messages, waiting up to 40 seconds for the first to land. 40s and not longer because the reference SDK's `DEFAULT_REQUEST_TIMEOUT_MSEC` is 60s and `resetTimeoutOnProgress` defaults to false, so an over-long wait is cancelled client-side rather than answered. Measured 40.1s, leaving 19.9s of margin. An empty return is normal, not an error, and the description says so.

**Every tool result now carries the unreplied count.** A client that cannot be pushed to still learns there is traffic on its next tool call, whatever that call was.

Claude Code is unaffected: the channel notification still fires and remains the fast path there.

Kept small deliberately: the `unreplied` formatter is now shared instead of duplicated, and the tool handler is wrapped rather than rewritten, so the switch body is untouched in the diff.

## How I tested it

Over a real MCP session against the server (initialize, `tools/list`, `tools/call`), with inbound messages simulated by writing to `messages.jsonl`, the same file the real inbound path writes.

| Behaviour | Result |
|---|---|
| nothing pending → waits rather than returning empty | PASS (still waiting at 8s) |
| message lands mid-wait → returns early | PASS (~1s after it landed, not at the cap) |
| already pending → returns immediately | PASS |
| count appended to an unrelated tool's result (`status`) | PASS |
| timeout path returns rather than hanging | PASS (40.1s, 19.9s margin under a 60s client timeout) |
| non-JSON stdout lines | 0 |

That last row is deliberate: at least one client (Cline) treats any non-JSON line on stdout as a protocol failure and kills the child process, so it is worth asserting rather than assuming.

`tsc --noEmit --strict` clean, `prettier --check` clean, the #14 lock harness still 22/22, doctor tests 17/17.

Known ceiling, marked with a comment in the code: the wait re-reads the message log every 2 seconds rather than being woken in-process. That is simpler, works no matter which code path wrote the line, and costs at most 2s of latency in a chat bridge. An in-process wake is the upgrade if that ever matters. I had the wake registry written and removed it: it duplicated the re-check, and it had silently failed a probe in a way the re-check caught.

## Checklist

- [x] `prettier --check` passes; `trunk` is not installed on this machine, relying on CI for `trunk check`.
- [ ] **Version bump** deliberately not included: this stacks on #14, which already moves `0.14.1` to `0.15.0`, and a second bump would collide on rebase. Happy to add one (`0.16.0`) if you would rather each PR carry its own.
- [x] No new runtime dependencies.
- [x] No runtime state / secrets committed.
- [x] Does not touch the singleton lock.
