### PR TITLE
fix(session-start): detect contacts in pretty-printed access.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "whatsapp-claude-channel",
       "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control, pairing, allowlists, and group policy.",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "source": "./",
       "category": "channels"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "whatsapp-claude-channel",
   "displayName": "WhatsApp Channel for Claude Code",
   "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /whatsapp-claude-channel:access.",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "author": {
     "name": "Rich627"
   },

--- a/hooks-handlers/session-start.sh
+++ b/hooks-handlers/session-start.sh
@@ -2,7 +2,7 @@
 
 # WhatsApp channel onboarding — checks setup state and guides user through next steps.
 
-STATE_DIR="${HOME}/.whatsapp-channel"
+STATE_DIR="${WHATSAPP_STATE_DIR:-${HOME}/.whatsapp-channel}"
 ENV_FILE="${STATE_DIR}/.env"
 AUTH_CREDS="${STATE_DIR}/.baileys_auth/creds.json"
 ACCESS_FILE="${STATE_DIR}/access.json"
@@ -20,11 +20,23 @@ if [ -f "$ENV_FILE" ] && grep -q 'WHATSAPP_PHONE_NUMBER=' "$ENV_FILE" 2>/dev/nul
 	has_phone=true
 fi
 
-if [ -f "$AUTH_CREDS" ] && grep -q '"registered":true' "$AUTH_CREDS" 2>/dev/null; then
+# Both JSON files are written pretty-printed (JSON.stringify with indent by
+# server.ts/scripts/access.ts; Baileys may do either), so a pattern must not
+# assume compact "key":value spacing — strip all whitespace before matching.
+# Grepping the file directly only ever matched compact JSON, which left
+# has_contacts false on every current install and buried the fully-configured
+# branch (and the update notice) below.
+json_has() {
+	local flat
+	flat="$(tr -d '[:space:]' <"${1}" 2>/dev/null)" || return 1
+	grep -q "${2}" <<<"${flat}"
+}
+
+if [[ -f ${AUTH_CREDS} ]] && json_has "${AUTH_CREDS}" '"registered":true'; then
 	has_auth=true
 fi
 
-if [ -f "$ACCESS_FILE" ] && grep -q '"allowFrom":\[".' "$ACCESS_FILE" 2>/dev/null; then
+if [[ -f ${ACCESS_FILE} ]] && json_has "${ACCESS_FILE}" '"allowFrom":\[".'; then
 	has_contacts=true
 fi
 

--- a/scripts/session-start.test.ts
+++ b/scripts/session-start.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Drives the real SessionStart hook (bash), not a reimplementation, against
+// a scratch WHATSAPP_STATE_DIR — the same override server.ts and
+// update-notice.ts honor. The hook always exits 0 and prints one JSON
+// object; what varies is additionalContext.
+const HOOK = join(import.meta.dir, "..", "hooks-handlers", "session-start.sh");
+const PLUGIN_VERSION: string = JSON.parse(
+  readFileSync(
+    join(import.meta.dir, "..", ".claude-plugin", "plugin.json"),
+    "utf8",
+  ),
+).version;
+
+function runHook(dir: string): string {
+  const out = execFileSync("bash", [HOOK], {
+    env: { ...process.env, WHATSAPP_STATE_DIR: dir },
+    encoding: "utf8",
+  });
+  return JSON.parse(out).hookSpecificOutput.additionalContext as string;
+}
+
+// A state dir as the current code actually writes it: pretty-printed JSON
+// everywhere (JSON.stringify(x, null, 2)).
+function configuredStateDir(opts: { allowFrom: string[] }): string {
+  const dir = mkdtempSync(join(tmpdir(), "wa-hook-"));
+  writeFileSync(join(dir, ".env"), "WHATSAPP_PHONE_NUMBER=886900000000\n");
+  mkdirSync(join(dir, ".baileys_auth"));
+  writeFileSync(
+    join(dir, ".baileys_auth", "creds.json"),
+    JSON.stringify({ registered: true }, null, 2) + "\n",
+  );
+  writeFileSync(
+    join(dir, "access.json"),
+    JSON.stringify(
+      { dmPolicy: "allowlist", allowFrom: opts.allowFrom, groups: {} },
+      null,
+      2,
+    ) + "\n",
+  );
+  // Keep the update notice quiet unless a test overwrites this — these tests
+  // are about the state-detection branches, not the notice.
+  writeFileSync(join(dir, ".last-seen-version"), PLUGIN_VERSION);
+  return dir;
+}
+
+describe("session-start.sh", () => {
+  // Regression: the old check grepped the file for compact
+  // '"allowFrom":[".' and never matched the pretty-printed form everything
+  // writes, so every configured install was greeted as having no contacts.
+  test("pretty-printed access.json with contacts → fully-configured message", () => {
+    const dir = configuredStateDir({
+      allowFrom: ["886900000000@s.whatsapp.net"],
+    });
+    expect(runHook(dir)).toContain("fully configured and ready");
+  });
+
+  test("compact (legacy) access.json with contacts is still recognized", () => {
+    const dir = configuredStateDir({
+      allowFrom: ["886900000000@s.whatsapp.net"],
+    });
+    writeFileSync(
+      join(dir, "access.json"),
+      '{"dmPolicy":"allowlist","allowFrom":["886900000000@s.whatsapp.net"],"groups":{}}\n',
+    );
+    expect(runHook(dir)).toContain("fully configured and ready");
+  });
+
+  test("empty allowFrom → still the no-contacts onboarding message", () => {
+    const dir = configuredStateDir({ allowFrom: [] });
+    expect(runHook(dir)).toContain("no contacts are allowlisted yet");
+  });
+
+  test("pretty-printed creds.json ('registered': true with space) counts as paired", () => {
+    // configuredStateDir writes creds pretty-printed already; getting past
+    // the has_auth branch to the fully-configured message proves it matched.
+    const dir = configuredStateDir({
+      allowFrom: ["886900000000@s.whatsapp.net"],
+    });
+    expect(runHook(dir)).not.toContain("not paired yet");
+  });
+
+  // The 0.18.0 update notice only fires from the fully-configured branch —
+  // exactly the branch this bug made unreachable, which is how it shipped
+  // dead. End-to-end through the hook, not just update-notice.ts's own tests.
+  test("update notice reaches the hook output when the recorded version is older", () => {
+    const dir = configuredStateDir({
+      allowFrom: ["886900000000@s.whatsapp.net"],
+    });
+    writeFileSync(join(dir, ".last-seen-version"), "0.9.0");
+    expect(runHook(dir)).toContain(
+      `WhatsApp plugin updated to v${PLUGIN_VERSION}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- The `has_contacts` check in `hooks-handlers/session-start.sh` grepped for the compact `"allowFrom":[".` form, but `server.ts` / `scripts/access.ts` always write `access.json` pretty-printed — so it never matched. Every configured install got the "no contacts are allowlisted yet" onboarding message on every session start, and the fully-configured branch (including #22's update notice) was unreachable. Found while rolling 0.18.0 out to a live deployment: `.last-seen-version` never appeared, and manually running the hook showed it stuck in the no-contacts branch.
- Fix: `json_has()` strips all whitespace before matching, and the `creds.json` `registered` check goes through it too (it only worked because Baileys happens to write compact JSON today). Compact legacy files still match.
- `STATE_DIR` now honors `WHATSAPP_STATE_DIR` (the override `server.ts` and `update-notice.ts` already support) so the hook is testable at all; new `scripts/session-start.test.ts` drives the real script.

## Test plan

- [x] `bun test` — 227 pass / 0 fail (14 files, includes the new hook suite)
- [x] `trunk check` on the changed files — no new issues
- [x] New coverage: pretty-printed access.json recognized (regression), compact legacy form still recognized, empty `allowFrom` still routes to onboarding, pretty-printed `creds.json` counts as paired, update notice reaches hook output end-to-end when the recorded version is older

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCEizdb9B1e379Snpb6ekk