### PR TITLE
Fix the statusline segment, make update notices reach the user, and give the wizard a revoke screen (0.21.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "whatsapp-channel",
       "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control, pairing, allowlists, and group policy.",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "source": "./",
       "category": "channels"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "whatsapp-channel",
   "displayName": "WhatsApp Channel for Claude Code",
   "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /whatsapp-channel:access.",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "author": {
     "name": "Rich627"
   },

--- a/ACCESS.md
+++ b/ACCESS.md
@@ -108,6 +108,17 @@ Both fail with a clear error if the group's `roster` flag isn't granted.
 - Ctrl-C cancels cleanly at any point; nothing is written until every question on screen has been answered.
 - A group the wizard adds gets `requireMention: true` (only reply when addressed) — a more cautious default than `group add`'s own CLI default of `false` (reply to everything), deliberately: the wizard is the guided path for a less technical setup, the CLI is for someone already comfortable with explicit flags. Change it after the fact with `group add --mention` or `--no-mention`.
 
+### Taking access back (`wizard --revoke`)
+
+`bun scripts/access.ts wizard --revoke` is the same screen in reverse: it lists **everything currently configured** — every group in `access.json`'s `groups`, every contact in `allowFrom` — and you tick what should lose access. Unlike the grant screen it is never capped or ranked: a revoke list that left entries off could leave them permanently unrevokable.
+
+- **Leaving everything unticked removes nothing.** An empty selection is never read as "remove all".
+- Revoking a group keeps its `config.md` and `memory.md`, same as `group rm`, in case you add it back.
+- Revoking a contact also forgets their cached name and recency — unless another allowlist entry still resolves to the same person (someone allowlisted under both their `@lid` and phone form), in which case the cache is kept, because the surviving grant still needs it.
+- Ctrl-C cancels cleanly, and nothing is written until every question on screen has been answered.
+
+It reads the same two functions the in-session `/whatsapp-claude-channel:access manage` screen reads, so the terminal and the chat path cannot disagree about what is configured or what a revoke cleans up.
+
 Group/contact names and recency come from caches (`~/.whatsapp-channel/groups-meta.json`, `dm-activity.json`, `contacts.json`) that only the running server writes — automatically, as WhatsApp reports chat activity, no manual step needed once the account has connected at least once. If it's never connected yet, the wizard has nothing to show; pair it first. `groups-meta.json` is always written; `dm-activity.json` and `contacts.json` follow `WHATSAPP_CACHE_CONTACTS` (see "Names and privacy" above) — with it off (the default), the DM screen has nothing to rank until you turn it on.
 
 It's a terminal command, deliberately not a Claude Code skill: running it yourself, outside any chat, is what makes this true —
@@ -160,7 +171,11 @@ This only controls whether Claude _announces_ a role change. The underlying prim
 
 ### Update notice
 
-The first Claude Code session that starts after the plugin's version has changed since it last recorded one (tracked per account in `~/.whatsapp-channel/.last-seen-version`) gets a one-time notice listing what changed, including a nudge toward the [guided setup wizard](#guided-bulk-setup-wizard) if you haven't run it yet — the wizard itself has always required running manually, this notice is just what tells you it exists. Shown once per version, not on every session start of the same version. Delivered by the SessionStart hook (`hooks-handlers/session-start.sh`, calling `scripts/update-notice.ts`), the same hook that guides first-time setup — a version bump has nothing to do with the WhatsApp connection itself, so it doesn't come from `server.ts`. Skipped in `WHATSAPP_ACCESS_MODE=static`, which can't write local state (see above).
+Two different notices, from the same script (`scripts/update-notice.ts`):
+
+**"What's new"** — the first Claude Code session that starts after the plugin's version has changed since it last recorded one (tracked per account in `~/.whatsapp-channel/.last-seen-version`) gets a one-time notice listing what changed, including a nudge toward the [guided setup wizard](#guided-bulk-setup-wizard) if you haven't run it yet — the wizard itself has always required running manually, this notice is just what tells you it exists. Shown once per version, not on every session start of the same version. Delivered by the SessionStart hook (`hooks-handlers/session-start.sh`, calling `scripts/update-notice.ts`), the same hook that guides first-time setup — a version bump has nothing to do with the WhatsApp connection itself, so it doesn't come from `server.ts`. Skipped in `WHATSAPP_ACCESS_MODE=static`, which can't write local state (see above).
+
+**"Update available"** — tells you a newer version exists that you have **not** installed yet, which the notice above can never do (it reads the running plugin's own `plugin.json`, so by the time it fires you already have the update). It compares the running version against what your marketplace clone advertises — both already on disk, refreshed by Claude Code itself, so there is no network call and nothing to configure. Unlike the one-time notice it is not gated on `.last-seen-version`: it repeats every session until you actually update, and goes quiet by itself once you do. Also skipped in static mode.
 
 ## Skill reference
 

--- a/ACCESS.md
+++ b/ACCESS.md
@@ -117,7 +117,7 @@ Both fail with a clear error if the group's `roster` flag isn't granted.
 - Revoking a contact also forgets their cached name and recency — unless another allowlist entry still resolves to the same person (someone allowlisted under both their `@lid` and phone form), in which case the cache is kept, because the surviving grant still needs it.
 - Ctrl-C cancels cleanly, and nothing is written until every question on screen has been answered.
 
-It reads the same two functions the in-session `/whatsapp-claude-channel:access manage` screen reads, so the terminal and the chat path cannot disagree about what is configured or what a revoke cleans up.
+It reads the same two functions the in-session `/whatsapp-channel:access manage` screen reads, so the terminal and the chat path cannot disagree about what is configured or what a revoke cleans up.
 
 Group/contact names and recency come from caches (`~/.whatsapp-channel/groups-meta.json`, `dm-activity.json`, `contacts.json`) that only the running server writes — automatically, as WhatsApp reports chat activity, no manual step needed once the account has connected at least once. If it's never connected yet, the wizard has nothing to show; pair it first. `groups-meta.json` is always written; `dm-activity.json` and `contacts.json` follow `WHATSAPP_CACHE_CONTACTS` (see "Names and privacy" above) — with it off (the default), the DM screen has nothing to rank until you turn it on.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -242,9 +242,8 @@ terminal, then looks for the plugin's own wrapper process among that CLI's
 descendants, then `server.ts` among that wrapper's children. Several
 processes can carry the plugin dir name in their command line, including
 the statusline shell itself, so every wrapper candidate is tried and the
-one with a `server.ts` under it wins. Same-machine, read-only, never throws
-
-- a miss just means no segment, not a broken statusline.
+one with a `server.ts` under it wins. Same-machine, read-only, never throws:
+a miss just means no segment, not a broken statusline.
 
 ## Known limitations
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -76,7 +76,7 @@ After pairing, the policy auto-locks back to `allowlist`.
 
 Each group gets its own personality config at `~/.whatsapp-channel/groups/<groupJid>/config.md`. Edit that file to customize how Claude behaves in each group. Conversation memory is auto-saved to `memory.md` in the same directory.
 
-See [ACCESS.md](./ACCESS.md) for group options (`--mention`, `--allow`, `--roster`). Setting up several groups or contacts at once? Run `bun scripts/access.ts wizard` in your own terminal for a checkbox pass over your most recently active ones — see [Guided bulk setup](./ACCESS.md#guided-bulk-setup-wizard).
+See [ACCESS.md](./ACCESS.md) for group options (`--mention`, `--allow`, `--roster`). Setting up several groups or contacts at once? Run `bun scripts/access.ts wizard` in your own terminal for a checkbox pass over your most recently active ones, or `wizard --revoke` to tick off access you want taken away — see [Guided bulk setup](./ACCESS.md#guided-bulk-setup-wizard).
 
 ## Daily use
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -234,16 +234,24 @@ glance which terminal holds the real connection:
 }
 ```
 
-It finds the server in three steps. A statusLine setting is a compound
-command, so the script runs under a shell that the CLI spawned separately
-from the plugin - a sibling of what it is looking for, not a descendant.
-So it first climbs the parent chain (a few hops) to the CLI that owns this
-terminal, then looks for the plugin's own wrapper process among that CLI's
-descendants, then `server.ts` among that wrapper's children. Several
-processes can carry the plugin dir name in their command line, including
-the statusline shell itself, so every wrapper candidate is tried and the
-one with a `server.ts` under it wins. Same-machine, read-only, never throws:
-a miss just means no segment, not a broken statusline.
+Each server records which Claude Code session owns it, so the segment reads
+ownership rather than guessing at it: the script climbs its own parent chain
+a few hops and takes the role file stamped with one of those pids. Another
+terminal's server can never match, and a leftover file from a dead session
+cannot either, since a dead process is nobody's parent.
+
+A server started before this shipped, or one whose client does not identify
+itself, has no stamp. For those the script falls back to the process tree:
+climb to the CLI that owns this terminal (a statusLine setting is a compound
+command, so the script runs under a shell that is the plugin's sibling, not
+its parent), find the plugin's wrapper among that CLI's descendants, then
+`server.ts` under the wrapper. Several processes can carry the plugin dir
+name - the statusline shell itself does - so every candidate is tried and
+the one with a `server.ts` under it wins. Restarting the session upgrades it
+to the stamped path.
+
+Same-machine, read-only, never throws: a miss just means no segment, not a
+broken statusline.
 
 ## Known limitations
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -234,10 +234,17 @@ glance which terminal holds the real connection:
 }
 ```
 
-It finds the server by walking down from the Claude Code CLI process:
-first the plugin's own wrapper process, then `server.ts` among that
-wrapper's children. Same-machine, read-only, never throws - a miss just
-means no segment, not a broken statusline.
+It finds the server in three steps. A statusLine setting is a compound
+command, so the script runs under a shell that the CLI spawned separately
+from the plugin - a sibling of what it is looking for, not a descendant.
+So it first climbs the parent chain (a few hops) to the CLI that owns this
+terminal, then looks for the plugin's own wrapper process among that CLI's
+descendants, then `server.ts` among that wrapper's children. Several
+processes can carry the plugin dir name in their command line, including
+the statusline shell itself, so every wrapper candidate is tried and the
+one with a `server.ts` under it wins. Same-machine, read-only, never throws
+
+- a miss just means no segment, not a broken statusline.
 
 ## Known limitations
 

--- a/hooks-handlers/session-start.sh
+++ b/hooks-handlers/session-start.sh
@@ -54,6 +54,12 @@ else
 	# nothing otherwise — a real bun script rather than more bash so version
 	# compare and JSON escaping reuse localeCompare/JSON.stringify instead
 	# of reimplementing both (see scripts/update-notice.ts).
+	# Keep this one message free of backslash escapes, unlike the three
+	# branches above. They are interpolated raw into the heredoc's JSON string,
+	# so their "\n" has to be pre-escaped; this one ALSO goes through
+	# JSON.stringify in update-notice.ts, which would escape the backslash
+	# again and ship a literal \n to the model. Plain prose reads identically
+	# down both paths.
 	msg="WhatsApp channel is fully configured and ready. Paired contacts can message this session."
 	# Passed in because the notice REPLACES this handler's output: the script
 	# carries this same message through on its own hookSpecificOutput, so a

--- a/hooks-handlers/session-start.sh
+++ b/hooks-handlers/session-start.sh
@@ -54,12 +54,17 @@ else
 	# nothing otherwise — a real bun script rather than more bash so version
 	# compare and JSON escaping reuse localeCompare/JSON.stringify instead
 	# of reimplementing both (see scripts/update-notice.ts).
-	notice_json="$(bun "${PLUGIN_ROOT}/scripts/update-notice.ts" 2>/dev/null)"
+	msg="WhatsApp channel is fully configured and ready. Paired contacts can message this session."
+	# Passed in because the notice REPLACES this handler's output: the script
+	# carries this same message through on its own hookSpecificOutput, so a
+	# session that gets a notice still briefs the model identically to one
+	# that does not. The notice itself rides on systemMessage, which goes to
+	# the user's screen instead of costing model context.
+	notice_json="$(bun "${PLUGIN_ROOT}/scripts/update-notice.ts" "${msg}" 2>/dev/null)"
 	if [[ -n ${notice_json} ]]; then
 		echo "${notice_json}"
 		exit 0
 	fi
-	msg="WhatsApp channel is fully configured and ready. Paired contacts can message this session."
 fi
 
 cat <<EOF

--- a/scripts/access.test.ts
+++ b/scripts/access.test.ts
@@ -814,3 +814,103 @@ describe("configured (JSON for the in-session manage/revoke screen)", () => {
     expect(readFileSync(join(dir, "access.json"), "utf8")).toBe(before);
   });
 });
+
+// Issue #1: until this existed the wizard could only ever GRANT, so an
+// existing user pointed at it by the update notice found no way to take
+// access back short of editing access.json by hand.
+describe("wizard --revoke", () => {
+  test("nothing configured: refuses with a clear message, writes nothing", () => {
+    const dir = freshStateDir();
+    const res = run(dir, "wizard", "--revoke");
+    expect(res.code).toBe(1);
+    expect(res.out).toContain("no access to take away");
+    expect(existsSync(join(dir, "access.json"))).toBe(false);
+  });
+
+  test.skipIf(!!process.env.CI)(
+    "select none: an empty selection removes NOTHING, never everything",
+    () => {
+      const dir = freshStateDir();
+      run(dir, "allow", "61403911675@s.whatsapp.net");
+      const before = readFileSync(join(dir, "access.json"), "utf8");
+      const res = runWithInput(dir, "\n", "wizard", "--revoke");
+      expect(res.code).toBe(0);
+      expect(res.out).toContain("Nothing selected");
+      expect(readFileSync(join(dir, "access.json"), "utf8")).toBe(before);
+    },
+  );
+
+  test.skipIf(!!process.env.CI)(
+    "select the one contact: dropped from the allowlist and forgotten",
+    () => {
+      const dir = freshStateDir();
+      writeContacts(dir, { "61403911675@s.whatsapp.net": { name: "Rohan" } });
+      writeDmActivity(dir, { "61403911675@s.whatsapp.net": 1000 });
+      run(dir, "allow", "61403911675@s.whatsapp.net");
+      const res = runWithInput(dir, " \n", "wizard", "--revoke");
+      expect(res.code).toBe(0);
+      // Labelled, not raw-numbered.
+      expect(res.out).toContain("Rohan");
+      expect(res.out).toContain("Forgot their cached name");
+      expect(access(dir).allowFrom).toEqual([]);
+      expect(readContacts(dir)["61403911675@s.whatsapp.net"]).toBeUndefined();
+    },
+  );
+
+  test.skipIf(!!process.env.CI)(
+    "select the one group: dropped, but its config.md and memory.md are kept",
+    () => {
+      const dir = freshStateDir();
+      writeGroupsMeta(dir, {
+        "1@g.us": {
+          name: "Family",
+          memberCount: 4,
+          archived: false,
+          updatedAt: 0,
+        },
+      });
+      run(dir, "group", "add", "1@g.us");
+      const config = join(dir, "groups", "1@g.us", "config.md");
+      expect(existsSync(config)).toBe(true);
+      const res = runWithInput(dir, " \n", "wizard", "--revoke");
+      expect(res.code).toBe(0);
+      expect(res.out).toContain("Family");
+      expect(access(dir).groups["1@g.us"]).toBeUndefined();
+      expect(existsSync(config)).toBe(true);
+    },
+  );
+
+  test.skipIf(!!process.env.CI)(
+    "revoking one form of a doubly-allowlisted contact keeps the shared cache",
+    () => {
+      // Same guard `remove` applies - shared through revokeCachedIdentity so
+      // the two screens cannot drift apart on it.
+      const dir = freshStateDir();
+      writeLidMap(dir, {
+        "228896205193224@lid": "61432609386@s.whatsapp.net",
+      });
+      writeContacts(dir, { "61432609386@s.whatsapp.net": { name: "Soham" } });
+      run(dir, "allow", "228896205193224@lid");
+      run(dir, "allow", "61432609386@s.whatsapp.net");
+      // Rows sort by label then JID, so the @lid form is first; space ticks
+      // it, enter submits.
+      const res = runWithInput(dir, " \n", "wizard", "--revoke");
+      expect(res.code).toBe(0);
+      expect(res.out).toContain("Kept their cached name");
+      expect(access(dir).allowFrom).toEqual(["61432609386@s.whatsapp.net"]);
+      expect(readContacts(dir)["61432609386@s.whatsapp.net"]).toEqual({
+        name: "Soham",
+      });
+    },
+  );
+
+  test.skipIf(!!process.env.CI)(
+    "still prints the no-AI disclosure - a revoke is as terminal-only as a grant",
+    () => {
+      const dir = freshStateDir();
+      run(dir, "allow", "1@s.whatsapp.net");
+      const res = runWithInput(dir, "\n", "wizard", "--revoke");
+      expect(res.out).toContain("No group or contact data was sent to any AI");
+    },
+  );
+});

--- a/scripts/access.ts
+++ b/scripts/access.ts
@@ -129,6 +129,8 @@ const USAGE = `Usage: bun scripts/access.ts <command>
   group rm <groupJid>             stop responding in a group (files kept)
   wizard [--include-archived]     guided group setup: can-act / can-see-roster,
                                    per group, from names cached by list_groups
+  wizard --revoke                 the same screen in reverse: tick what to
+                                   take access AWAY from
   candidates [--include-archived] JSON: groups/contacts not configured yet
   configured                      JSON: groups/contacts already configured
   set <key> <value>               ${SET_KEYS.join(", ")}
@@ -475,6 +477,91 @@ async function wizard(args: string[]): Promise<void> {
   process.stdout.write(`\n${highlight(PRIVACY_DISCLOSURE)}\n`);
 }
 
+// The revoke half of the terminal wizard (issue #1). Until this existed the
+// only supported way to take access back was `remove`/`group rm` one JID at
+// a time, or editing access.json by hand - while the wizard's own update
+// notice pointed users at it as though it were the access screen.
+//
+// Reuses listConfiguredGroups/listConfiguredDms, the same two functions the
+// in-session `manage` screen reads through `configured`, so the terminal and
+// the in-session path cannot disagree about what is configured, how a row is
+// labelled, or what a revoke cleans up.
+//
+// Same terminal-only, no-model guarantee as the grant screen above, and the
+// same rule in both: an empty selection removes NOTHING. A revoke screen
+// that read "no ticks" as "remove all" would be a catastrophe on a mis-Enter.
+async function wizardRevoke(): Promise<void> {
+  const a = load();
+  const groups = listConfiguredGroups(a.groups, loadGroupsMeta());
+  const dms = listConfiguredDms(a.allowFrom, loadContacts(), loadLidMap());
+
+  if (groups.length === 0 && dms.length === 0) {
+    die("Nothing is configured yet - there is no access to take away.");
+  }
+
+  let dropGroups: string[] = [];
+  let dropDms: string[] = [];
+  try {
+    if (groups.length > 0) {
+      dropGroups = await checkbox({
+        message:
+          "Which groups should Claude STOP replying in? (leave all unticked to keep everything)",
+        choices: groups.map((c) => ({ name: c.label, value: c.jid })),
+      });
+    }
+    if (dms.length > 0) {
+      dropDms = await checkbox({
+        message:
+          "Which contacts should lose DM access? (leave all unticked to keep everything)",
+        choices: dms.map((c) => ({ name: c.label, value: c.jid })),
+      });
+    }
+  } catch (err) {
+    if (err instanceof Error && err.name === "ExitPromptError") {
+      process.stdout.write("\nCancelled - nothing was changed.\n");
+      return;
+    }
+    throw err;
+  }
+
+  if (dropGroups.length === 0 && dropDms.length === 0) {
+    process.stdout.write("\nNothing selected - nothing was changed.\n");
+    process.stdout.write(`\n${highlight(PRIVACY_DISCLOSURE)}\n`);
+    return;
+  }
+
+  // Re-load for the same reason the grant screen does: the checkbox prompts
+  // block on the user for an unbounded time and the server can write
+  // access.json in that window.
+  const fresh = load();
+  for (const jid of dropGroups) delete fresh.groups[jid];
+  // Filtered by exact string, never a LID-resolved substitute - the
+  // candidate's jid is the untouched allowFrom entry precisely so this
+  // matches (see listConfiguredDms).
+  fresh.allowFrom = fresh.allowFrom.filter((j) => !dropDms.includes(j));
+  save(fresh);
+
+  const lines: string[] = [];
+  for (const jid of dropGroups) {
+    const label = groups.find((c) => c.jid === jid)?.label ?? jid;
+    lines.push(`- ${label}: Claude will not reply there any more.`);
+  }
+  for (const jid of dropDms) {
+    const label = dms.find((c) => c.jid === jid)?.label ?? jid;
+    lines.push(
+      `- ${label}: DM access removed.${CACHE_NOTE[revokeCachedIdentity(fresh.allowFrom, jid)]}`,
+    );
+  }
+
+  process.stdout.write(`\n${lines.join("\n")}\n`);
+  if (dropGroups.length > 0) {
+    process.stdout.write(
+      "\nTheir config.md and memory.md are kept, in case you add them back.\n",
+    );
+  }
+  process.stdout.write(`\n${highlight(PRIVACY_DISCLOSURE)}\n`);
+}
+
 // Read-only JSON for the in-session `review` and `manage` screens in
 // skills/access/SKILL.md. The skill EXECUTES these instead of restating
 // the ranking and labelling rules in prose: every drift a review has caught
@@ -561,6 +648,39 @@ function forgetCachedIdentity(jid: string): boolean {
   return forgot || forgotActivity;
 }
 
+// What revoking ONE allowlist entry should do to that contact's cached
+// name and recency. Shared by `remove` and the wizard's revoke screen so
+// the rule cannot drift between them - it has two edges that are easy to
+// get wrong separately:
+//
+//  - One person can sit in allowFrom TWICE, under both their @lid and their
+//    phone form, and both resolve to the same cache key. Revoking one form
+//    while the other still grants access must keep the cache, or the
+//    surviving grant goes on working while the contact silently degrades to
+//    a bare masked number everywhere.
+//  - Claiming to have forgotten (or kept) a cached name that never existed
+//    is a false statement to the user either way, so "nothing" is a distinct
+//    answer from both.
+//
+// `remaining` is allowFrom AFTER the entry has been taken out.
+type CacheOutcome = "forgot" | "kept" | "nothing";
+const CACHE_NOTE: Record<CacheOutcome, string> = {
+  forgot: " Forgot their cached name too.",
+  kept: " Kept their cached name - another allowlist entry still resolves to the same contact.",
+  nothing: "",
+};
+function revokeCachedIdentity(
+  remaining: readonly string[],
+  jid: string,
+): CacheOutcome {
+  const lidMap = loadLidMap();
+  const key = contactKeyFor(lidMap, jid);
+  const stillAllowed = remaining.some((j) => contactKeyFor(lidMap, j) === key);
+  if (!stillAllowed) return forgetCachedIdentity(jid) ? "forgot" : "nothing";
+  const cached = key in loadContacts() || key in loadDmActivity();
+  return cached ? "kept" : "nothing";
+}
+
 function set(key: string, rawValue: string): void {
   if (!SET_KEYS.includes(key)) {
     die(`Unknown key "${key}". Supported: ${SET_KEYS.join(", ")}`);
@@ -626,32 +746,8 @@ switch (command) {
     if (!a.allowFrom.includes(jid)) die(`${jid} is not on the allowlist.`);
     a.allowFrom = a.allowFrom.filter((j) => j !== jid);
     save(a);
-    // One contact can sit in allowFrom twice, under both its @lid and its
-    // phone form, and BOTH resolve to the same contacts.json /
-    // dm-activity.json key. Revoking one form while the other still grants
-    // access must not wipe that shared cache: the surviving grant would go
-    // on working while the contact silently degraded to a bare masked
-    // number everywhere, and this command would report them "forgotten"
-    // while they could still message Claude.
-    const lidMap = loadLidMap();
-    const key = contactKeyFor(lidMap, jid);
-    const stillAllowed = a.allowFrom.some(
-      (j) => contactKeyFor(lidMap, j) === key,
-    );
-    // Guarded on something actually being cached, the same way the
-    // "Forgot" half is: a contact allowlisted by JID who has never DMed
-    // has no cached name, and claiming one was KEPT is as wrong as
-    // claiming one was forgotten.
-    const cached = key in loadContacts() || key in loadDmActivity();
-    const forgot = stillAllowed ? false : forgetCachedIdentity(jid);
-    process.stdout.write(
-      `Removed ${jid}.` +
-        (forgot ? " Forgot their cached name too." : "") +
-        (stillAllowed && cached
-          ? " Kept their cached name - another allowlist entry still resolves to the same contact."
-          : "") +
-        "\n",
-    );
+    const outcome = revokeCachedIdentity(a.allowFrom, jid);
+    process.stdout.write(`Removed ${jid}.` + CACHE_NOTE[outcome] + "\n");
     break;
   }
   case "forget": {
@@ -684,7 +780,8 @@ switch (command) {
     group(rest);
     break;
   case "wizard":
-    await wizard(rest);
+    if (rest.includes("--revoke")) await wizardRevoke();
+    else await wizard(rest);
     break;
   case "candidates":
     candidates(rest);

--- a/scripts/server-conflict.test.ts
+++ b/scripts/server-conflict.test.ts
@@ -62,3 +62,36 @@ describe("conflict mode", () => {
     }
   }, 60_000);
 });
+
+// Issue #4: shutdown() only removes the role file on a graceful exit, so a
+// killed or crashed server leaves one behind forever. The sweep runs before
+// the singleton lock is taken, which is what lets this test see it: the
+// server planted against a live lock refuses and exits, and must STILL have
+// tidied up on its way through.
+describe("stale role file sweep", () => {
+  test("removes role files of dead pids and keeps live ones", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wa-rolesweep-"));
+    const dead = join(dir, ".role-999999");
+    const live = join(dir, `.role-${process.pid}`);
+    const notOurs = join(dir, ".role-not-a-pid");
+    writeFileSync(dead, "primary\n999999\n");
+    writeFileSync(live, "secondary\n1\n");
+    writeFileSync(notOurs, "primary");
+
+    const child = spawn("bun", [SERVER], {
+      env: { ...process.env, WHATSAPP_STATE_DIR: dir },
+      stdio: ["pipe", "ignore", "pipe"],
+      windowsHide: true,
+    });
+    try {
+      for (let i = 0; i < 60 && existsSync(dead); i++) await sleep(500);
+      expect(existsSync(dead)).toBe(false);
+      // A live pid's file belongs to a running server - never ours to remove.
+      expect(existsSync(live)).toBe(true);
+      // Not .role-<number>, so not this sweep's business.
+      expect(existsSync(notOurs)).toBe(true);
+    } finally {
+      child.kill();
+    }
+  }, 60_000);
+});

--- a/scripts/session-start.test.ts
+++ b/scripts/session-start.test.ts
@@ -7,7 +7,8 @@ import { join } from "node:path";
 // Drives the real SessionStart hook (bash), not a reimplementation, against
 // a scratch WHATSAPP_STATE_DIR — the same override server.ts and
 // update-notice.ts honor. The hook always exits 0 and prints one JSON
-// object; what varies is additionalContext.
+// object; what varies is additionalContext (model-facing) and, when there is
+// an update to announce, systemMessage (user-facing).
 const HOOK = join(import.meta.dir, "..", "hooks-handlers", "session-start.sh");
 const PLUGIN_VERSION: string = JSON.parse(
   readFileSync(
@@ -16,12 +17,17 @@ const PLUGIN_VERSION: string = JSON.parse(
   ),
 ).version;
 
+function runHookRaw(dir: string): Record<string, any> {
+  return JSON.parse(
+    execFileSync("bash", [HOOK], {
+      env: { ...process.env, WHATSAPP_STATE_DIR: dir },
+      encoding: "utf8",
+    }),
+  );
+}
+
 function runHook(dir: string): string {
-  const out = execFileSync("bash", [HOOK], {
-    env: { ...process.env, WHATSAPP_STATE_DIR: dir },
-    encoding: "utf8",
-  });
-  return JSON.parse(out).hookSpecificOutput.additionalContext as string;
+  return runHookRaw(dir).hookSpecificOutput.additionalContext as string;
 }
 
 // A state dir as the current code actually writes it: pretty-printed JSON
@@ -92,8 +98,14 @@ describe("session-start.sh", () => {
       allowFrom: ["886900000000@s.whatsapp.net"],
     });
     writeFileSync(join(dir, ".last-seen-version"), "0.9.0");
-    expect(runHook(dir)).toContain(
+    const out = runHookRaw(dir);
+    // The notice itself is user-facing, and the model still gets the same
+    // briefing it would have had with no notice at all.
+    expect(out.systemMessage).toContain(
       `WhatsApp plugin updated to v${PLUGIN_VERSION}`,
+    );
+    expect(out.hookSpecificOutput.additionalContext).toContain(
+      "fully configured and ready",
     );
   });
 });

--- a/scripts/statusline-role.test.ts
+++ b/scripts/statusline-role.test.ts
@@ -397,10 +397,7 @@ describe("roleFromOwnerStamp", () => {
   // The whole point: two terminals, two servers, and the only thing telling
   // them apart is which session each server says it belongs to. The process
   // tree cannot decide this once a shared ancestor is in range.
-  const files = [
-    { content: "primary\n100\n" },
-    { content: "secondary\n200\n" },
-  ];
+  const files = ["primary\n100\n", "secondary\n200\n"];
 
   test("takes the file stamped with one of our own ancestors", () => {
     expect(roleFromOwnerStamp(files, [400, 300, 200])).toBe("secondary");
@@ -418,19 +415,15 @@ describe("roleFromOwnerStamp", () => {
   // A dead pid is nobody's ancestor, so a leftover file from a crashed
   // session drops out with no liveness check of its own.
   test("stale files from dead sessions cannot match", () => {
-    expect(
-      roleFromOwnerStamp([{ content: "primary\n999999\n" }], [1, 2]),
-    ).toBeNull();
+    expect(roleFromOwnerStamp(["primary\n999999\n"], [1, 2])).toBeNull();
   });
 
   // Pre-stamp servers write the bare role with no line 2. Unusable here on
   // purpose - main() falls back to the tree search for exactly this case.
   test("ignores an unstamped file rather than guessing it is ours", () => {
-    expect(roleFromOwnerStamp([{ content: "primary" }], [100])).toBeNull();
-    expect(
-      roleFromOwnerStamp([{ content: "primary\nnot-a-pid\n" }], [100]),
-    ).toBeNull();
-    expect(roleFromOwnerStamp([{ content: "" }], [100])).toBeNull();
+    expect(roleFromOwnerStamp(["primary"], [100])).toBeNull();
+    expect(roleFromOwnerStamp(["primary\nnot-a-pid\n"], [100])).toBeNull();
+    expect(roleFromOwnerStamp([""], [100])).toBeNull();
   });
 });
 

--- a/scripts/statusline-role.test.ts
+++ b/scripts/statusline-role.test.ts
@@ -3,7 +3,12 @@ import { execFileSync, spawn } from "node:child_process";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { findServerPid, formatSegment, type ProcRow } from "./statusline-role";
+import {
+  findServerPid,
+  findServerPidForTerminal,
+  formatSegment,
+  type ProcRow,
+} from "./statusline-role";
 
 describe("findServerPid", () => {
   test("matches the real CLI -> plugin wrapper -> server.ts chain", () => {
@@ -162,5 +167,155 @@ describe("end-to-end (real processes)", () => {
       "server.ts",
     );
     expect(out).toBe("");
+  });
+});
+
+// Issue #3. Every fixture above hands findServerPid the CLI pid directly,
+// which is why they all passed while the segment never rendered on a real
+// machine: a statusLine setting is a compound command, so the script runs
+// under a shell that is the wrapper's SIBLING, and a downward search from
+// there can never reach it.
+describe("findServerPidForTerminal", () => {
+  // claude.exe(100) ├── wrapper(200) ── server(300)
+  //                 └── statusline shell(400)   <- process.ppid
+  const siblingShell: ProcRow[] = [
+    { pid: 100, ppid: 1, command: "claude.exe" },
+    {
+      pid: 200,
+      ppid: 100,
+      command: "bun run --cwd plugin/whatsapp-claude-channel/0.1 start",
+    },
+    { pid: 300, ppid: 200, command: "bun.exe server.ts" },
+    { pid: 400, ppid: 100, command: "sh -c statusline-command.sh && bun ..." },
+  ];
+
+  test("finds the server when it starts at a SIBLING of the wrapper", () => {
+    // The regression: searching down from 400 alone returns null.
+    expect(
+      findServerPid(siblingShell, 400, "whatsapp-claude-channel", "server.ts"),
+    ).toBeNull();
+    expect(
+      findServerPidForTerminal(
+        siblingShell,
+        400,
+        "whatsapp-claude-channel",
+        "server.ts",
+      ),
+    ).toBe(300);
+  });
+
+  test("still works when started at the CLI itself, no climb needed", () => {
+    expect(
+      findServerPidForTerminal(
+        siblingShell,
+        100,
+        "whatsapp-claude-channel",
+        "server.ts",
+      ),
+    ).toBe(300);
+  });
+
+  test("climbs through an extra shell hop", () => {
+    const nested: ProcRow[] = [
+      ...siblingShell,
+      { pid: 500, ppid: 400, command: "bun statusline-role.ts" },
+    ];
+    expect(
+      findServerPidForTerminal(
+        nested,
+        500,
+        "whatsapp-claude-channel",
+        "server.ts",
+      ),
+    ).toBe(300);
+  });
+
+  // The climb is bounded on purpose: with two terminals there are two CLIs,
+  // each with its own wrapper, and climbing far enough to reach a shared
+  // host would show the OTHER terminal's role.
+  test("stops climbing at the hop limit rather than reaching further up", () => {
+    const deep: ProcRow[] = [
+      { pid: 1, ppid: 0, command: "host" },
+      {
+        pid: 2,
+        ppid: 1,
+        command: "bun run --cwd plugin/whatsapp-claude-channel/0.1 start",
+      },
+      { pid: 3, ppid: 2, command: "bun.exe server.ts" },
+      { pid: 10, ppid: 1, command: "a" },
+      { pid: 11, ppid: 10, command: "b" },
+      { pid: 12, ppid: 11, command: "c" },
+      { pid: 13, ppid: 12, command: "d" },
+      { pid: 14, ppid: 13, command: "statusline" },
+    ];
+    expect(
+      findServerPidForTerminal(
+        deep,
+        14,
+        "whatsapp-claude-channel",
+        "server.ts",
+        1,
+      ),
+    ).toBeNull();
+  });
+
+  test("nearest ancestor wins, so a sibling terminal's server is not picked", () => {
+    const twoTerminals: ProcRow[] = [
+      { pid: 1, ppid: 0, command: "terminal host" },
+      // Terminal A, further up.
+      { pid: 10, ppid: 1, command: "claude.exe A" },
+      {
+        pid: 11,
+        ppid: 10,
+        command: "bun run --cwd plugin/whatsapp-claude-channel/0.1 start",
+      },
+      { pid: 12, ppid: 11, command: "bun.exe server.ts" },
+      // Terminal B, ours.
+      { pid: 20, ppid: 1, command: "claude.exe B" },
+      {
+        pid: 21,
+        ppid: 20,
+        command: "bun run --cwd plugin/whatsapp-claude-channel/0.1 start",
+      },
+      { pid: 22, ppid: 21, command: "bun.exe server.ts" },
+      { pid: 23, ppid: 20, command: "sh -c statusline" },
+    ];
+    expect(
+      findServerPidForTerminal(
+        twoTerminals,
+        23,
+        "whatsapp-claude-channel",
+        "server.ts",
+      ),
+    ).toBe(22);
+  });
+
+  test("a self-parenting row or a pid 0 parent terminates instead of spinning", () => {
+    // Both shapes turn up in real Win32_Process output.
+    const loop: ProcRow[] = [
+      { pid: 7, ppid: 7, command: "self-parenting" },
+      { pid: 8, ppid: 0, command: "orphan" },
+    ];
+    expect(
+      findServerPidForTerminal(loop, 7, "whatsapp-claude-channel", "server.ts"),
+    ).toBeNull();
+    expect(
+      findServerPidForTerminal(loop, 8, "whatsapp-claude-channel", "server.ts"),
+    ).toBeNull();
+  });
+
+  test("returns null when nothing in the chain owns a wrapper", () => {
+    const none: ProcRow[] = [
+      { pid: 100, ppid: 1, command: "claude.exe" },
+      { pid: 400, ppid: 100, command: "sh -c statusline" },
+    ];
+    expect(
+      findServerPidForTerminal(
+        none,
+        400,
+        "whatsapp-claude-channel",
+        "server.ts",
+      ),
+    ).toBeNull();
   });
 });

--- a/scripts/statusline-role.test.ts
+++ b/scripts/statusline-role.test.ts
@@ -4,9 +4,11 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  ancestorChain,
   findServerPid,
   findServerPidForTerminal,
   formatSegment,
+  roleFromOwnerStamp,
   type ProcRow,
 } from "./statusline-role";
 
@@ -101,6 +103,35 @@ describe("end-to-end (real processes)", () => {
       },
     });
   }
+
+  // The stamped path, end to end through the real script: no wrapper and no
+  // server process exist here at all, so this can only pass by reading the
+  // owner pid out of the file. The decoy is a second terminal's server, which
+  // the process tree alone would have no way to rule out.
+  test("reads the stamped owner instead of hunting the process tree", () => {
+    const dir = freshStateDir();
+    writeFileSync(join(dir, ".role-4242"), `secondary\n${process.pid}\n`);
+    writeFileSync(join(dir, ".role-4243"), "primary\n999999\n");
+    const out = runStatusline(
+      dir,
+      process.pid,
+      "no-such-wrapper",
+      "no-such-server",
+    );
+    expect(out).toContain("WA:secondary");
+    expect(out).not.toContain("primary");
+  });
+
+  // Same fixture minus the stamp: nothing matches, and with no wrapper or
+  // server process to fall back to the script stays silent rather than
+  // picking the only file it can see.
+  test("stays silent when the only files belong to someone else", () => {
+    const dir = freshStateDir();
+    writeFileSync(join(dir, ".role-4243"), "primary\n999999\n");
+    expect(
+      runStatusline(dir, process.pid, "no-such-wrapper", "no-such-server"),
+    ).toBe("");
+  });
 
   // Spawns a real two-hop process chain (this test -> "wrapper" -> "server")
   // mirroring the real CLI -> plugin wrapper -> server.ts topology, and
@@ -359,5 +390,66 @@ describe("findServerPidForTerminal", () => {
         "server.ts",
       ),
     ).toBeNull();
+  });
+});
+
+describe("roleFromOwnerStamp", () => {
+  // The whole point: two terminals, two servers, and the only thing telling
+  // them apart is which session each server says it belongs to. The process
+  // tree cannot decide this once a shared ancestor is in range.
+  const files = [
+    { content: "primary\n100\n" },
+    { content: "secondary\n200\n" },
+  ];
+
+  test("takes the file stamped with one of our own ancestors", () => {
+    expect(roleFromOwnerStamp(files, [400, 300, 200])).toBe("secondary");
+    expect(roleFromOwnerStamp(files, [900, 100])).toBe("primary");
+  });
+
+  test("a sibling terminal's server is never ours", () => {
+    expect(roleFromOwnerStamp(files, [700, 800])).toBeNull();
+  });
+
+  test("nearest ancestor wins when a session runs inside another", () => {
+    expect(roleFromOwnerStamp(files, [200, 100])).toBe("secondary");
+  });
+
+  // A dead pid is nobody's ancestor, so a leftover file from a crashed
+  // session drops out with no liveness check of its own.
+  test("stale files from dead sessions cannot match", () => {
+    expect(
+      roleFromOwnerStamp([{ content: "primary\n999999\n" }], [1, 2]),
+    ).toBeNull();
+  });
+
+  // Pre-stamp servers write the bare role with no line 2. Unusable here on
+  // purpose - main() falls back to the tree search for exactly this case.
+  test("ignores an unstamped file rather than guessing it is ours", () => {
+    expect(roleFromOwnerStamp([{ content: "primary" }], [100])).toBeNull();
+    expect(
+      roleFromOwnerStamp([{ content: "primary\nnot-a-pid\n" }], [100]),
+    ).toBeNull();
+    expect(roleFromOwnerStamp([{ content: "" }], [100])).toBeNull();
+  });
+});
+
+describe("ancestorChain", () => {
+  const rows: ProcRow[] = [
+    { pid: 10, ppid: 1, command: "host" },
+    { pid: 20, ppid: 10, command: "claude" },
+    { pid: 30, ppid: 20, command: "shell" },
+  ];
+
+  test("lists self then parents, nearest first", () => {
+    expect(ancestorChain(rows, 30)).toEqual([30, 20, 10, 1]);
+  });
+
+  test("stops at the hop bound", () => {
+    expect(ancestorChain(rows, 30, 1)).toEqual([30, 20]);
+  });
+
+  test("stops at a pid that is not in the table", () => {
+    expect(ancestorChain(rows, 999)).toEqual([999]);
   });
 });

--- a/scripts/statusline-role.test.ts
+++ b/scripts/statusline-role.test.ts
@@ -204,6 +204,48 @@ describe("findServerPidForTerminal", () => {
     ).toBe(300);
   });
 
+  // Regression: the documented statusLine command is
+  // `... && bun <plugin-dir>/scripts/statusline-role.ts`, and <plugin-dir>
+  // ends in the plugin name — so the shell's OWN command line contains the
+  // wrapper pattern, at the same BFS depth as the real wrapper. A
+  // first-match-wins search picks whichever row the OS listed first, and
+  // Win32_Process rows are not pid-ordered, so the segment blanked out
+  // unpredictably. Both orderings must resolve to the real server.
+  //
+  // The fixture above dodges this by giving its shell a command with no
+  // plugin path in it, which is why 295 passing tests never caught it.
+  const realWiring = (shellFirst: boolean): ProcRow[] => {
+    const plugin = "plugins/cache/wa/whatsapp-claude-channel/0.20.0";
+    const cli: ProcRow = { pid: 100, ppid: 1, command: "claude.exe" };
+    const shell: ProcRow = {
+      pid: 400,
+      ppid: 100,
+      command: `sh -c "statusline.sh && bun ${plugin}/scripts/statusline-role.ts"`,
+    };
+    const wrapper: ProcRow = {
+      pid: 200,
+      ppid: 100,
+      command: `bun run --cwd ${plugin} start`,
+    };
+    const server: ProcRow = { pid: 300, ppid: 200, command: "bun server.ts" };
+    return shellFirst
+      ? [cli, shell, wrapper, server]
+      : [cli, wrapper, server, shell];
+  };
+
+  test("ignores a decoy carrying the plugin name, whichever order it is listed in", () => {
+    for (const shellFirst of [true, false]) {
+      expect(
+        findServerPidForTerminal(
+          realWiring(shellFirst),
+          400,
+          "whatsapp-claude-channel",
+          "server.ts",
+        ),
+      ).toBe(300);
+    }
+  });
+
   test("still works when started at the CLI itself, no climb needed", () => {
     expect(
       findServerPidForTerminal(

--- a/scripts/statusline-role.test.ts
+++ b/scripts/statusline-role.test.ts
@@ -246,7 +246,7 @@ describe("findServerPidForTerminal", () => {
   // The fixture above dodges this by giving its shell a command with no
   // plugin path in it, which is why 295 passing tests never caught it.
   const realWiring = (shellFirst: boolean): ProcRow[] => {
-    const plugin = "plugins/cache/wa/whatsapp-claude-channel/0.20.0";
+    const plugin = "plugins/cache/wa/whatsapp-channel/0.21.0";
     const cli: ProcRow = { pid: 100, ppid: 1, command: "claude.exe" };
     const shell: ProcRow = {
       pid: 400,
@@ -270,7 +270,7 @@ describe("findServerPidForTerminal", () => {
         findServerPidForTerminal(
           realWiring(shellFirst),
           400,
-          "whatsapp-claude-channel",
+          "whatsapp-channel",
           "server.ts",
         ),
       ).toBe(300);

--- a/scripts/statusline-role.ts
+++ b/scripts/statusline-role.ts
@@ -7,20 +7,24 @@
  * already prints, e.g.:
  *   your-existing-statusline-command && bun <plugin-dir>/scripts/statusline-role.ts
  *
- * Finds the server in three steps: climb the ppid chain to the Claude Code
- * CLI that owns this terminal (this script does NOT run as its direct child
- * — see findServerPidForTerminal), then the plugin's own wrapper process
- * among that CLI's descendants (identified by the plugin dir name — unique
- * even when another plugin's server also happens to be named server.ts,
- * which is common enough that matching "server.ts" against the whole process
- * tree picks the wrong one), then server.ts among *that wrapper's* children
- * specifically. Reads the matched pid's role file (written by server.ts on
- * every role change — see ROLE_FILE there). Never throws, never writes:
- * prints nothing and exits 0 on any miss, same contract as the tool it's
- * meant to sit quietly next to.
+ * Two ways to find the right server, in order.
+ *
+ * 1. The stamp. server.ts writes the pid of the Claude Code session that owns
+ *    it as line 2 of its role file, so we climb our own ppid chain and take
+ *    the file whose owner is one of our ancestors. Ownership is read, not
+ *    guessed, so a sibling terminal's server can never be mistaken for ours.
+ * 2. The process tree, for a server that predates the stamp or a client that
+ *    never identified itself: climb the ppid chain to the Claude Code CLI
+ *    (this script does NOT run as its direct child — see
+ *    findServerPidForTerminal), then the plugin's own wrapper among that
+ *    CLI's descendants (matched on the plugin dir name — "server.ts" alone
+ *    hits other plugins' servers too), then server.ts under that wrapper.
+ *
+ * Never throws, never writes: prints nothing and exits 0 on any miss, same
+ * contract as the tool it's meant to sit quietly next to.
  */
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -180,20 +184,65 @@ export function findServerPid(
 // two CLIs each with their own wrapper, and an arbitrary pick would show the
 // OTHER terminal's role — the one thing this segment exists to tell apart.
 //
-// ponytail: bounded climb, 3 hops. Ceiling: if this terminal has no server
-// of its own AND a host process (a terminal app owning several tabs) sits
-// within 3 hops, the climb reaches a sibling terminal's wrapper and shows
-// ITS role. Note this is now the deterministic outcome, not a coincidence:
-// findServerPid tries every candidate, so once a sibling's wrapper is in
-// range its live server.ts always wins over this terminal's own wrapper that
-// has none (still starting, or shut down). A confident wrong label, where
-// the first-match version would more often have rendered nothing. Blank was
-// the honest answer, so this trade is only acceptable because the reach
-// needs a tab host inside 3 hops, which no layout seen so far has.
-// 3 covers shell -> [shell] -> CLI with one hop spare. Real fix when it
-// bites: have server.ts record the owning CLI pid in the role file and match
-// on it, instead of inferring ownership from the process tree.
+// Bounded climb, 3 hops: enough for shell -> [shell] -> CLI with one spare.
+//
+// This tree walk can only tell "a server under this terminal" from "a server
+// under a sibling terminal" while no shared ancestor is in range - and when
+// one is, it picks the sibling's LIVE server over this terminal's own wrapper
+// that has none yet, i.e. a confident wrong label rather than a blank. That
+// is why roleFromOwnerStamp exists and runs first; this path is the
+// compatibility fallback, kept only for a server that has not restarted since
+// the stamp shipped, or a client that never sets CLAUDE_PID.
 const ANCESTOR_MAX_HOPS = 3;
+
+// This process, then its parent, then its parent's parent, nearest first.
+export function ancestorChain(
+  rows: ProcRow[],
+  startPid: number,
+  maxHops: number = ANCESTOR_MAX_HOPS,
+): number[] {
+  const byPid = new Map(rows.map((r) => [r.pid, r]));
+  const chain: number[] = [];
+  let pid: number | undefined = startPid;
+  for (let hop = 0; hop <= maxHops; hop++) {
+    // pid 0 and a self-parenting row both appear in real Win32_Process
+    // output. Neither can spin this loop - the hop bound ends it either way -
+    // so this only skips the pointless work they would otherwise cause.
+    if (pid === undefined || pid <= 0) break;
+    chain.push(pid);
+    pid = byPid.get(pid)?.ppid;
+  }
+  return chain;
+}
+
+// The stamped path (preferred): server.ts writes the pid of the Claude Code
+// session that owns it as line 2 of its role file, so ownership is READ
+// rather than inferred. A file whose owner is one of our own ancestors is
+// ours by definition - a sibling terminal's server can never match, however
+// close it sits in the process tree, and a stale file from a dead session
+// cannot either, since a dead pid is nobody's ancestor.
+//
+// Nearest ancestor first, so the innermost session wins if a Claude Code
+// session ever runs inside another one.
+export function roleFromOwnerStamp(
+  files: { content: string }[],
+  ancestors: number[],
+): string | null {
+  const owners = new Map<number, string>();
+  for (const f of files) {
+    const [role, owner] = f.content.split("\n");
+    const ownerPid = Number((owner ?? "").trim());
+    // No line 2 at all: a server predating the stamp, or a client that never
+    // identified itself. Unusable here - the tree search still covers it.
+    if (!role || !Number.isInteger(ownerPid) || ownerPid <= 0) continue;
+    if (!owners.has(ownerPid)) owners.set(ownerPid, role.trim());
+  }
+  for (const pid of ancestors) {
+    const role = owners.get(pid);
+    if (role) return role;
+  }
+  return null;
+}
 
 export function findServerPidForTerminal(
   rows: ProcRow[],
@@ -202,16 +251,9 @@ export function findServerPidForTerminal(
   serverMatch: string,
   maxHops: number = ANCESTOR_MAX_HOPS,
 ): number | null {
-  const byPid = new Map(rows.map((r) => [r.pid, r]));
-  let pid: number | undefined = startPid;
-  for (let hop = 0; hop <= maxHops; hop++) {
-    // pid 0 and a self-parenting row both appear in real Win32_Process
-    // output. Neither can spin this loop - the hop bound ends it either way -
-    // so this only skips the pointless scans they would otherwise cause.
-    if (pid === undefined || pid <= 0) return null;
+  for (const pid of ancestorChain(rows, startPid, maxHops)) {
     const found = findServerPid(rows, pid, wrapperMatch, serverMatch);
     if (found !== null) return found;
-    pid = byPid.get(pid)?.ppid;
   }
   return null;
 }
@@ -221,10 +263,40 @@ export function formatSegment(role: string): string {
   return color ? `${color}WA:${role}${RESET}` : "";
 }
 
+// Every role file in the state dir. Missing dir, unreadable file, no files
+// at all: an empty list, same as every other miss in here.
+function readRoleFiles(): { content: string }[] {
+  try {
+    return readdirSync(STATE_DIR)
+      .filter((f) => f.startsWith(".role-"))
+      .map((f) => {
+        try {
+          return { content: readFileSync(join(STATE_DIR, f), "utf8") };
+        } catch {
+          return { content: "" };
+        }
+      });
+  } catch {
+    return [];
+  }
+}
+
 function main(): void {
   try {
+    const rows = listProcesses();
+    const ancestors = ancestorChain(rows, PARENT_PID);
+    // Stamped ownership first. The tree search below is the fallback for a
+    // server that has not been restarted since this shipped, or a client that
+    // does not identify itself - it can confuse a sibling terminal's server
+    // for ours, which is exactly what the stamp exists to prevent.
+    const stamped = roleFromOwnerStamp(readRoleFiles(), ancestors);
+    if (stamped) {
+      const segment = formatSegment(stamped);
+      if (segment) process.stdout.write(segment);
+      return;
+    }
     const pid = findServerPidForTerminal(
-      listProcesses(),
+      rows,
       PARENT_PID,
       WRAPPER_MATCH,
       SERVER_MATCH,
@@ -232,7 +304,10 @@ function main(): void {
     if (pid === null) return;
     const roleFile = join(STATE_DIR, `.role-${pid}`);
     if (!existsSync(roleFile)) return;
-    const segment = formatSegment(readFileSync(roleFile, "utf8").trim());
+    // Line 1 only: a stamped file has the owner pid on line 2.
+    const segment = formatSegment(
+      readFileSync(roleFile, "utf8").split("\n")[0]!.trim(),
+    );
     if (segment) process.stdout.write(segment);
   } catch {
     // A broken statusline segment is worse than a missing one.

--- a/scripts/statusline-role.ts
+++ b/scripts/statusline-role.ts
@@ -225,12 +225,12 @@ export function ancestorChain(
 // Nearest ancestor first, so the innermost session wins if a Claude Code
 // session ever runs inside another one.
 export function roleFromOwnerStamp(
-  files: { content: string }[],
+  files: string[],
   ancestors: number[],
 ): string | null {
   const owners = new Map<number, string>();
   for (const f of files) {
-    const [role, owner] = f.content.split("\n");
+    const [role, owner] = f.split("\n");
     const ownerPid = Number((owner ?? "").trim());
     // No line 2 at all: a server predating the stamp, or a client that never
     // identified itself. Unusable here - the tree search still covers it.
@@ -265,15 +265,15 @@ export function formatSegment(role: string): string {
 
 // Every role file in the state dir. Missing dir, unreadable file, no files
 // at all: an empty list, same as every other miss in here.
-function readRoleFiles(): { content: string }[] {
+function readRoleFiles(): string[] {
   try {
     return readdirSync(STATE_DIR)
       .filter((f) => f.startsWith(".role-"))
       .map((f) => {
         try {
-          return { content: readFileSync(join(STATE_DIR, f), "utf8") };
+          return readFileSync(join(STATE_DIR, f), "utf8");
         } catch {
-          return { content: "" };
+          return "";
         }
       });
   } catch {

--- a/scripts/statusline-role.ts
+++ b/scripts/statusline-role.ts
@@ -109,20 +109,56 @@ function findDescendant(
   return null;
 }
 
+// EVERY match, shallowest first, because the wrapper pattern is the plugin
+// dir name and more than one child of the CLI legitimately carries it in its
+// command line: the statusline's own shell does (the documented wiring is
+// `... && bun <plugin-dir>/scripts/statusline-role.ts`), this very script
+// does, and so does any `bun <plugin-dir>/scripts/access.ts` the session
+// happens to run. Win32_Process rows are not pid-ordered, so a first-match
+// search picks an arbitrary one of them and the segment blanks out whenever
+// that pick has no server.ts under it - the original bug, downgraded from
+// permanent to intermittent, which is worse to diagnose.
+function findDescendants(
+  rows: ProcRow[],
+  rootPid: number,
+  match: string,
+  maxDepth: number,
+): number[] {
+  const hits: number[] = [];
+  let frontier = new Set([rootPid]);
+  for (let depth = 0; depth < maxDepth; depth++) {
+    const children = rows.filter((r) => frontier.has(r.ppid));
+    for (const c of children) if (c.command.includes(match)) hits.push(c.pid);
+    frontier = new Set(children.map((r) => r.pid));
+    if (frontier.size === 0) break;
+  }
+  return hits;
+}
+
 export function findServerPid(
   rows: ProcRow[],
   cliPid: number,
   wrapperMatch: string,
   serverMatch: string,
 ): number | null {
-  const wrapperPid = findDescendant(
+  // A candidate is only the real wrapper if server.ts sits under it. The
+  // decoys above have no such child, so they cost one scan of their own
+  // (empty) subtree each and nothing else.
+  for (const wrapperPid of findDescendants(
     rows,
     cliPid,
     wrapperMatch,
     WRAPPER_MAX_DEPTH,
-  );
-  if (wrapperPid === null) return null;
-  return findDescendant(rows, wrapperPid, serverMatch, SERVER_MAX_DEPTH);
+  )) {
+    const serverPid = findDescendant(
+      rows,
+      wrapperPid,
+      serverMatch,
+      SERVER_MAX_DEPTH,
+    );
+    if (serverPid !== null) return serverPid;
+  }
+  return null;
 }
 
 // The bug this exists for (issue #3): a statusLine setting is a compound
@@ -161,13 +197,12 @@ export function findServerPidForTerminal(
   maxHops: number = ANCESTOR_MAX_HOPS,
 ): number | null {
   const byPid = new Map(rows.map((r) => [r.pid, r]));
-  const visited = new Set<number>();
   let pid: number | undefined = startPid;
   for (let hop = 0; hop <= maxHops; hop++) {
     // pid 0 and a self-parenting row both appear in real Win32_Process
-    // output; either would spin this loop forever without the guards.
-    if (pid === undefined || pid <= 0 || visited.has(pid)) return null;
-    visited.add(pid);
+    // output. Neither can spin this loop - the hop bound ends it either way -
+    // so this only skips the pointless scans they would otherwise cause.
+    if (pid === undefined || pid <= 0) return null;
     const found = findServerPid(rows, pid, wrapperMatch, serverMatch);
     if (found !== null) return found;
     pid = byPid.get(pid)?.ppid;

--- a/scripts/statusline-role.ts
+++ b/scripts/statusline-role.ts
@@ -182,9 +182,15 @@ export function findServerPid(
 //
 // ponytail: bounded climb, 3 hops. Ceiling: if this terminal has no server
 // of its own AND a host process (a terminal app owning several tabs) sits
-// within 3 hops, the climb can reach a sibling terminal's wrapper and show
-// its role. 3 covers shell -> [shell] -> CLI with one hop spare and stops
-// short of a tab host in the layouts seen so far. Real fix if that ever
+// within 3 hops, the climb reaches a sibling terminal's wrapper and shows
+// ITS role. Note this is now the deterministic outcome, not a coincidence:
+// findServerPid tries every candidate, so once a sibling's wrapper is in
+// range its live server.ts always wins over this terminal's own wrapper that
+// has none (still starting, or shut down). A confident wrong label, where
+// the first-match version would more often have rendered nothing. Blank was
+// the honest answer, so this trade is only acceptable because the reach
+// needs a tab host inside 3 hops, which no layout seen so far has.
+// 3 covers shell -> [shell] -> CLI with one hop spare. Real fix when it
 // bites: have server.ts record the owning CLI pid in the role file and match
 // on it, instead of inferring ownership from the process tree.
 const ANCESTOR_MAX_HOPS = 3;

--- a/scripts/statusline-role.ts
+++ b/scripts/statusline-role.ts
@@ -7,15 +7,17 @@
  * already prints, e.g.:
  *   your-existing-statusline-command && bun <plugin-dir>/scripts/statusline-role.ts
  *
- * Finds the server in two steps: first the plugin's own wrapper process
- * (a descendant of the Claude Code CLI that spawned this statusline command,
- * identified by the plugin dir name — unique even when another plugin's
- * server also happens to be named server.ts, which is common enough that
- * matching "server.ts" against the whole process tree picks the wrong one),
- * then server.ts among *that wrapper's* children specifically. Reads the
- * matched pid's role file (written by server.ts on every role change — see
- * ROLE_FILE there). Never throws, never writes: prints nothing and exits 0
- * on any miss, same contract as the tool it's meant to sit quietly next to.
+ * Finds the server in three steps: climb the ppid chain to the Claude Code
+ * CLI that owns this terminal (this script does NOT run as its direct child
+ * — see findServerPidForTerminal), then the plugin's own wrapper process
+ * among that CLI's descendants (identified by the plugin dir name — unique
+ * even when another plugin's server also happens to be named server.ts,
+ * which is common enough that matching "server.ts" against the whole process
+ * tree picks the wrong one), then server.ts among *that wrapper's* children
+ * specifically. Reads the matched pid's role file (written by server.ts on
+ * every role change — see ROLE_FILE there). Never throws, never writes:
+ * prints nothing and exits 0 on any miss, same contract as the tool it's
+ * meant to sit quietly next to.
  */
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
@@ -25,8 +27,10 @@ import { join } from "node:path";
 const STATE_DIR =
   process.env.WHATSAPP_STATE_DIR ?? join(homedir(), ".whatsapp-channel");
 // Overridable for tests only — production matches this plugin's own dir
-// name (unique across the process tree) and walks up to this script's real
-// parent, the Claude Code CLI.
+// name, which is unique across the process tree. NOTE process.ppid is NOT
+// the Claude Code CLI: a statusLine setting is a compound command, so this
+// runs under a shell the CLI spawned separately. findServerPidForTerminal
+// is what gets from here to the CLI.
 const WRAPPER_MATCH =
   process.env.WA_STATUSLINE_WRAPPER_MATCH ?? "whatsapp-channel";
 const SERVER_MATCH = process.env.WA_STATUSLINE_MATCH ?? "server.ts";
@@ -121,6 +125,56 @@ export function findServerPid(
   return findDescendant(rows, wrapperPid, serverMatch, SERVER_MAX_DEPTH);
 }
 
+// The bug this exists for (issue #3): a statusLine setting is a compound
+// command, so this script runs under a shell that the CLI spawned SEPARATELY
+// from the plugin wrapper. The shell is the wrapper's SIBLING, not its
+// ancestor:
+//
+//   claude.exe (CLI)
+//   ├── bun run --cwd <plugin> start   (wrapper)
+//   │   └── bun server.ts              <- the role file lives here
+//   └── sh -c "<statusline command>"   <- process.ppid, where we start
+//
+// So searching down from process.ppid could never reach the wrapper, and
+// the segment silently never rendered from PR #18 until now. Climb to the
+// first common ancestor instead, retrying the wrapper search at each hop,
+// nearest first.
+//
+// Deliberately NOT a scan of the whole process table: two terminals means
+// two CLIs each with their own wrapper, and an arbitrary pick would show the
+// OTHER terminal's role — the one thing this segment exists to tell apart.
+//
+// ponytail: bounded climb, 3 hops. Ceiling: if this terminal has no server
+// of its own AND a host process (a terminal app owning several tabs) sits
+// within 3 hops, the climb can reach a sibling terminal's wrapper and show
+// its role. 3 covers shell -> [shell] -> CLI with one hop spare and stops
+// short of a tab host in the layouts seen so far. Real fix if that ever
+// bites: have server.ts record the owning CLI pid in the role file and match
+// on it, instead of inferring ownership from the process tree.
+const ANCESTOR_MAX_HOPS = 3;
+
+export function findServerPidForTerminal(
+  rows: ProcRow[],
+  startPid: number,
+  wrapperMatch: string,
+  serverMatch: string,
+  maxHops: number = ANCESTOR_MAX_HOPS,
+): number | null {
+  const byPid = new Map(rows.map((r) => [r.pid, r]));
+  const visited = new Set<number>();
+  let pid: number | undefined = startPid;
+  for (let hop = 0; hop <= maxHops; hop++) {
+    // pid 0 and a self-parenting row both appear in real Win32_Process
+    // output; either would spin this loop forever without the guards.
+    if (pid === undefined || pid <= 0 || visited.has(pid)) return null;
+    visited.add(pid);
+    const found = findServerPid(rows, pid, wrapperMatch, serverMatch);
+    if (found !== null) return found;
+    pid = byPid.get(pid)?.ppid;
+  }
+  return null;
+}
+
 export function formatSegment(role: string): string {
   const color = COLOR[role];
   return color ? `${color}WA:${role}${RESET}` : "";
@@ -128,7 +182,7 @@ export function formatSegment(role: string): string {
 
 function main(): void {
   try {
-    const pid = findServerPid(
+    const pid = findServerPidForTerminal(
       listProcesses(),
       PARENT_PID,
       WRAPPER_MATCH,

--- a/scripts/update-notice.test.ts
+++ b/scripts/update-notice.test.ts
@@ -142,7 +142,7 @@ describe("update available", () => {
   function fakeInstall(
     installed: string,
     marketplacePlugins: { name?: string; version?: string }[] | null,
-    pluginName = "whatsapp-claude-channel",
+    pluginName = "whatsapp-channel",
     marketplaceName = "whatsapp-claude-plugin",
   ): string {
     const root = mkdtempSync(join(tmpdir(), "wa-install-"));
@@ -205,18 +205,18 @@ describe("update available", () => {
 
   test("announces a newer version that is on offer but not installed", () => {
     const script = fakeInstall("0.19.0", [
-      { name: "whatsapp-claude-channel", version: "0.20.0" },
+      { name: "whatsapp-channel", version: "0.20.0" },
     ]);
     const ctx = JSON.parse(runInstalled(script, currentState("0.19.0")))
       .systemMessage as string;
     expect(ctx).toContain("v0.20.0");
     expect(ctx).toContain("v0.19.0");
-    expect(ctx).toContain("claude plugin update whatsapp-claude-channel");
+    expect(ctx).toContain("claude plugin update whatsapp-channel");
   });
 
   test("says nothing when the installed version is already the offered one", () => {
     const script = fakeInstall("0.19.0", [
-      { name: "whatsapp-claude-channel", version: "0.19.0" },
+      { name: "whatsapp-channel", version: "0.19.0" },
     ]);
     expect(runInstalled(script, currentState("0.19.0"))).toBe("");
   });
@@ -224,14 +224,14 @@ describe("update available", () => {
   test("says nothing when the install is AHEAD of the marketplace", () => {
     // A local dev build, or a marketplace clone that has not refreshed yet.
     const script = fakeInstall("0.20.0", [
-      { name: "whatsapp-claude-channel", version: "0.19.0" },
+      { name: "whatsapp-channel", version: "0.19.0" },
     ]);
     expect(runInstalled(script, currentState("0.20.0"))).toBe("");
   });
 
   test("numeric version compare, so 0.9.0 is not treated as newer than 0.19.0", () => {
     const script = fakeInstall("0.19.0", [
-      { name: "whatsapp-claude-channel", version: "0.9.0" },
+      { name: "whatsapp-channel", version: "0.9.0" },
     ]);
     expect(runInstalled(script, currentState("0.19.0"))).toBe("");
   });
@@ -239,7 +239,7 @@ describe("update available", () => {
   test("picks its OWN entry, not whichever plugin the marketplace lists first", () => {
     const script = fakeInstall("0.19.0", [
       { name: "some-other-plugin", version: "9.9.9" },
-      { name: "whatsapp-claude-channel", version: "0.20.0" },
+      { name: "whatsapp-channel", version: "0.20.0" },
     ]);
     const ctx = JSON.parse(runInstalled(script, currentState("0.19.0")))
       .systemMessage as string;
@@ -254,7 +254,7 @@ describe("update available", () => {
 
   test("a marketplace file that is not valid JSON is silent, not a crash", () => {
     const script = fakeInstall("0.19.0", [
-      { name: "whatsapp-claude-channel", version: "0.20.0" },
+      { name: "whatsapp-channel", version: "0.20.0" },
     ]);
     // script is <root>/plugins/cache/<mkt>/<plugin>/<ver>/scripts/x.ts, so
     // six hops up lands on <root>/plugins.
@@ -280,7 +280,7 @@ describe("update available", () => {
   // the model failed to relay it would be the only session that ever had it.
   test("repeats every session - it is not gated on the seen-version marker", () => {
     const script = fakeInstall("0.19.0", [
-      { name: "whatsapp-claude-channel", version: "0.20.0" },
+      { name: "whatsapp-channel", version: "0.20.0" },
     ]);
     const dir = currentState("0.19.0");
     expect(runInstalled(script, dir)).not.toBe("");
@@ -292,7 +292,7 @@ describe("update available", () => {
   // and only seen if the model chooses to repeat it).
   test("the notice goes to the user channel, never into model context", () => {
     const script = fakeInstall("0.19.0", [
-      { name: "whatsapp-claude-channel", version: "0.20.0" },
+      { name: "whatsapp-channel", version: "0.20.0" },
     ]);
     const out = JSON.parse(runInstalled(script, currentState("0.19.0")));
     expect(out.systemMessage).toContain("v0.20.0");
@@ -306,7 +306,7 @@ describe("update available", () => {
   // session that happens to see a notice would brief the model with nothing.
   test("carries the caller's model-facing message through untouched", () => {
     const script = fakeInstall("0.19.0", [
-      { name: "whatsapp-claude-channel", version: "0.20.0" },
+      { name: "whatsapp-channel", version: "0.20.0" },
     ]);
     const out = JSON.parse(
       runInstalled(script, currentState("0.19.0"), "briefing for the model"),

--- a/scripts/update-notice.test.ts
+++ b/scripts/update-notice.test.ts
@@ -36,7 +36,7 @@ describe("update-notice.ts", () => {
     const dir = mkdtempSync(join(tmpdir(), "wa-notice-old-"));
     writeFileSync(join(dir, ".last-seen-version"), "0.9.0");
     const parsed = JSON.parse(run(dir));
-    const ctx = parsed.hookSpecificOutput.additionalContext as string;
+    const ctx = parsed.systemMessage as string;
     expect(ctx).toContain(
       `WhatsApp plugin updated to v${PLUGIN_VERSION} (from v0.9.0)`,
     );
@@ -55,7 +55,7 @@ describe("update-notice.ts", () => {
   test("first-ever run (never recorded) still writes the marker and shows only the latest entry", () => {
     const dir = mkdtempSync(join(tmpdir(), "wa-notice-first-"));
     const parsed = JSON.parse(run(dir));
-    const ctx = parsed.hookSpecificOutput.additionalContext as string;
+    const ctx = parsed.systemMessage as string;
     expect(ctx).toContain(`WhatsApp plugin updated to v${PLUGIN_VERSION}`);
     expect(ctx).not.toContain("(from v");
     expect(readFileSync(join(dir, ".last-seen-version"), "utf8")).toBe(
@@ -70,8 +70,7 @@ describe("update-notice.ts", () => {
   // is exactly why that went unnoticed.
   test("first-ever run shows the NEWEST changelog entry, not the oldest", () => {
     const dir = mkdtempSync(join(tmpdir(), "wa-notice-newest-"));
-    const ctx = JSON.parse(run(dir)).hookSpecificOutput
-      .additionalContext as string;
+    const ctx = JSON.parse(run(dir)).systemMessage as string;
     expect(ctx).toContain("--revoke");
     expect(ctx).not.toContain("Proactive notifications");
   });
@@ -164,11 +163,19 @@ describe("update available", () => {
     return join(pluginDir, "scripts", "update-notice.ts");
   }
 
-  function runInstalled(script: string, stateDir: string): string {
-    return execFileSync("bun", [script], {
-      env: { ...process.env, WHATSAPP_STATE_DIR: stateDir },
-      encoding: "utf8",
-    });
+  function runInstalled(
+    script: string,
+    stateDir: string,
+    modelContext?: string,
+  ): string {
+    return execFileSync(
+      "bun",
+      modelContext ? [script, modelContext] : [script],
+      {
+        env: { ...process.env, WHATSAPP_STATE_DIR: stateDir },
+        encoding: "utf8",
+      },
+    );
   }
 
   function currentState(version: string): string {
@@ -184,7 +191,7 @@ describe("update available", () => {
       { name: "whatsapp-claude-channel", version: "0.20.0" },
     ]);
     const ctx = JSON.parse(runInstalled(script, currentState("0.19.0")))
-      .hookSpecificOutput.additionalContext as string;
+      .systemMessage as string;
     expect(ctx).toContain("v0.20.0");
     expect(ctx).toContain("v0.19.0");
     expect(ctx).toContain("claude plugin update whatsapp-claude-channel");
@@ -218,7 +225,7 @@ describe("update available", () => {
       { name: "whatsapp-claude-channel", version: "0.20.0" },
     ]);
     const ctx = JSON.parse(runInstalled(script, currentState("0.19.0")))
-      .hookSpecificOutput.additionalContext as string;
+      .systemMessage as string;
     expect(ctx).toContain("v0.20.0");
     expect(ctx).not.toContain("9.9.9");
   });
@@ -263,12 +270,34 @@ describe("update available", () => {
     expect(runInstalled(script, dir)).not.toBe("");
   });
 
-  test("the notice tells the model to relay it, since this output never reaches the screen", () => {
+  // The notice is for the human, so it must ride on systemMessage (shown to
+  // them) and NOT on additionalContext (folded into model context, billed,
+  // and only seen if the model chooses to repeat it).
+  test("the notice goes to the user channel, never into model context", () => {
     const script = fakeInstall("0.19.0", [
       { name: "whatsapp-claude-channel", version: "0.20.0" },
     ]);
-    const ctx = JSON.parse(runInstalled(script, currentState("0.19.0")))
-      .hookSpecificOutput.additionalContext as string;
-    expect(ctx.startsWith("Tell the user")).toBe(true);
+    const out = JSON.parse(runInstalled(script, currentState("0.19.0")));
+    expect(out.systemMessage).toContain("v0.20.0");
+    expect(JSON.stringify(out.hookSpecificOutput ?? {})).not.toContain(
+      "v0.20.0",
+    );
+  });
+
+  // The notice replaces the calling hook's entire JSON output, so the caller
+  // hands its model-facing message over to be carried through. Without it a
+  // session that happens to see a notice would brief the model with nothing.
+  test("carries the caller's model-facing message through untouched", () => {
+    const script = fakeInstall("0.19.0", [
+      { name: "whatsapp-claude-channel", version: "0.20.0" },
+    ]);
+    const out = JSON.parse(
+      runInstalled(script, currentState("0.19.0"), "briefing for the model"),
+    );
+    expect(out.hookSpecificOutput.additionalContext).toBe(
+      "briefing for the model",
+    );
+    expect(out.hookSpecificOutput.hookEventName).toBe("SessionStart");
+    expect(out.systemMessage).toContain("v0.20.0");
   });
 });

--- a/scripts/update-notice.test.ts
+++ b/scripts/update-notice.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -80,5 +86,162 @@ describe("update-notice.ts", () => {
     writeFileSync(join(dir, ".last-seen-version"), '0.9.0"; \\ malicious');
     const out = run(dir);
     expect(() => JSON.parse(out)).not.toThrow();
+  });
+});
+
+// Issue #2: the notice above can only ever announce a version the user
+// ALREADY has, so the plugin could never say "a newer one is waiting".
+// These build a real install tree in a temp dir - cache/<marketplace>/
+// <plugin>/<version> next to marketplaces/<marketplace>/ - and run the real
+// script from inside it, so the path derivation itself is under test, not a
+// stubbed-out version of it.
+describe("update available", () => {
+  function fakeInstall(
+    installed: string,
+    marketplacePlugins: { name?: string; version?: string }[] | null,
+    pluginName = "whatsapp-claude-channel",
+    marketplaceName = "whatsapp-claude-plugin",
+  ): string {
+    const root = mkdtempSync(join(tmpdir(), "wa-install-"));
+    const pluginDir = join(
+      root,
+      "plugins",
+      "cache",
+      marketplaceName,
+      pluginName,
+      installed,
+    );
+    mkdirSync(join(pluginDir, "scripts"), { recursive: true });
+    mkdirSync(join(pluginDir, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(pluginDir, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: pluginName, version: installed }),
+    );
+    for (const f of ["update-notice.ts", "wizard-cmd.ts"]) {
+      copyFileSync(join(import.meta.dir, f), join(pluginDir, "scripts", f));
+    }
+    if (marketplacePlugins !== null) {
+      const mktDir = join(
+        root,
+        "plugins",
+        "marketplaces",
+        marketplaceName,
+        ".claude-plugin",
+      );
+      mkdirSync(mktDir, { recursive: true });
+      writeFileSync(
+        join(mktDir, "marketplace.json"),
+        JSON.stringify({ name: marketplaceName, plugins: marketplacePlugins }),
+      );
+    }
+    return join(pluginDir, "scripts", "update-notice.ts");
+  }
+
+  function runInstalled(script: string, stateDir: string): string {
+    return execFileSync("bun", [script], {
+      env: { ...process.env, WHATSAPP_STATE_DIR: stateDir },
+      encoding: "utf8",
+    });
+  }
+
+  function currentState(version: string): string {
+    const dir = mkdtempSync(join(tmpdir(), "wa-notice-avail-"));
+    // Marker already current, so the "what's new" notice cannot fire and
+    // anything printed is the available-update notice alone.
+    writeFileSync(join(dir, ".last-seen-version"), version);
+    return dir;
+  }
+
+  test("announces a newer version that is on offer but not installed", () => {
+    const script = fakeInstall("0.19.0", [
+      { name: "whatsapp-claude-channel", version: "0.20.0" },
+    ]);
+    const ctx = JSON.parse(runInstalled(script, currentState("0.19.0")))
+      .hookSpecificOutput.additionalContext as string;
+    expect(ctx).toContain("v0.20.0");
+    expect(ctx).toContain("v0.19.0");
+    expect(ctx).toContain("claude plugin update whatsapp-claude-channel");
+  });
+
+  test("says nothing when the installed version is already the offered one", () => {
+    const script = fakeInstall("0.19.0", [
+      { name: "whatsapp-claude-channel", version: "0.19.0" },
+    ]);
+    expect(runInstalled(script, currentState("0.19.0"))).toBe("");
+  });
+
+  test("says nothing when the install is AHEAD of the marketplace", () => {
+    // A local dev build, or a marketplace clone that has not refreshed yet.
+    const script = fakeInstall("0.20.0", [
+      { name: "whatsapp-claude-channel", version: "0.19.0" },
+    ]);
+    expect(runInstalled(script, currentState("0.20.0"))).toBe("");
+  });
+
+  test("numeric version compare, so 0.9.0 is not treated as newer than 0.19.0", () => {
+    const script = fakeInstall("0.19.0", [
+      { name: "whatsapp-claude-channel", version: "0.9.0" },
+    ]);
+    expect(runInstalled(script, currentState("0.19.0"))).toBe("");
+  });
+
+  test("picks its OWN entry, not whichever plugin the marketplace lists first", () => {
+    const script = fakeInstall("0.19.0", [
+      { name: "some-other-plugin", version: "9.9.9" },
+      { name: "whatsapp-claude-channel", version: "0.20.0" },
+    ]);
+    const ctx = JSON.parse(runInstalled(script, currentState("0.19.0")))
+      .hookSpecificOutput.additionalContext as string;
+    expect(ctx).toContain("v0.20.0");
+    expect(ctx).not.toContain("9.9.9");
+  });
+
+  test("no marketplace clone at all (a repo checkout) is silent, not a crash", () => {
+    const script = fakeInstall("0.19.0", null);
+    expect(runInstalled(script, currentState("0.19.0"))).toBe("");
+  });
+
+  test("a marketplace file that is not valid JSON is silent, not a crash", () => {
+    const script = fakeInstall("0.19.0", [
+      { name: "whatsapp-claude-channel", version: "0.20.0" },
+    ]);
+    // script is <root>/plugins/cache/<mkt>/<plugin>/<ver>/scripts/x.ts, so
+    // six hops up lands on <root>/plugins.
+    const bad = join(
+      script,
+      "..",
+      "..",
+      "..",
+      "..",
+      "..",
+      "..",
+      "marketplaces",
+      "whatsapp-claude-plugin",
+      ".claude-plugin",
+      "marketplace.json",
+    );
+    writeFileSync(bad, "{ not json");
+    expect(runInstalled(script, currentState("0.19.0"))).toBe("");
+  });
+
+  // The "what's new" notice burns its one chance the moment it fires, because
+  // the marker advances right after. This one must not, or a session where
+  // the model failed to relay it would be the only session that ever had it.
+  test("repeats every session - it is not gated on the seen-version marker", () => {
+    const script = fakeInstall("0.19.0", [
+      { name: "whatsapp-claude-channel", version: "0.20.0" },
+    ]);
+    const dir = currentState("0.19.0");
+    expect(runInstalled(script, dir)).not.toBe("");
+    expect(runInstalled(script, dir)).not.toBe("");
+  });
+
+  test("the notice tells the model to relay it, since this output never reaches the screen", () => {
+    const script = fakeInstall("0.19.0", [
+      { name: "whatsapp-claude-channel", version: "0.20.0" },
+    ]);
+    const ctx = JSON.parse(runInstalled(script, currentState("0.19.0")))
+      .hookSpecificOutput.additionalContext as string;
+    expect(ctx.startsWith("Tell the user")).toBe(true);
   });
 });

--- a/scripts/update-notice.test.ts
+++ b/scripts/update-notice.test.ts
@@ -63,6 +63,33 @@ describe("update-notice.ts", () => {
     );
   });
 
+  // Regression: CHANGELOG is newest-first, so the no-marker fallback has to
+  // take the HEAD of the array. slice(-1) took the tail — the OLDEST entry —
+  // and shipped a notice headed with the current version over notes from the
+  // first release in the file. The test above asserts only the header, which
+  // is exactly why that went unnoticed.
+  test("first-ever run shows the NEWEST changelog entry, not the oldest", () => {
+    const dir = mkdtempSync(join(tmpdir(), "wa-notice-newest-"));
+    const ctx = JSON.parse(run(dir)).hookSpecificOutput
+      .additionalContext as string;
+    expect(ctx).toContain("--revoke");
+    expect(ctx).not.toContain("Proactive notifications");
+  });
+
+  // Regression: a downgrade leaves changedVersion true while the version
+  // filter matches nothing, which emitted "updated to v<older>" over an empty
+  // bullet list — a false claim the model is explicitly told to relay. The
+  // marker still has to advance, or every later session repeats the mistake.
+  test("a downgrade says nothing but still records the version", () => {
+    const dir = mkdtempSync(join(tmpdir(), "wa-notice-downgrade-"));
+    writeFileSync(join(dir, ".last-seen-version"), "99.0.0");
+    const out = run(dir);
+    expect(out).not.toContain("What's new");
+    expect(readFileSync(join(dir, ".last-seen-version"), "utf8")).toBe(
+      PLUGIN_VERSION,
+    );
+  });
+
   test("skipped entirely in static mode (env var) — no output, no write", () => {
     const dir = mkdtempSync(join(tmpdir(), "wa-notice-static-env-"));
     writeFileSync(join(dir, ".last-seen-version"), "0.1.0");

--- a/scripts/update-notice.test.ts
+++ b/scripts/update-notice.test.ts
@@ -89,6 +89,23 @@ describe("update-notice.ts", () => {
     );
   });
 
+  // The head-of-CHANGELOG fallback above is only truthful while the head IS
+  // the shipping version. Bump plugin.json without adding an entry and the
+  // first-run notice says "updated to v0.21.0" over v0.20.0's bullets - the
+  // same header/body mismatch, one version narrower. Nothing else enforces
+  // the pairing, so this test is the enforcement: it fails at release time,
+  // when adding the missing entry is trivial.
+  test("the newest CHANGELOG entry is the version actually shipping", () => {
+    const dir = mkdtempSync(join(tmpdir(), "wa-notice-invariant-"));
+    const ctx = JSON.parse(run(dir)).systemMessage as string;
+    const source = readFileSync(join(import.meta.dir, "update-notice.ts"), {
+      encoding: "utf8",
+    });
+    const firstEntry = source.match(/version:\s*"([^"]+)"/)?.[1];
+    expect(firstEntry).toBe(PLUGIN_VERSION);
+    expect(ctx).toContain(`updated to v${PLUGIN_VERSION}`);
+  });
+
   test("skipped entirely in static mode (env var) — no output, no write", () => {
     const dir = mkdtempSync(join(tmpdir(), "wa-notice-static-env-"));
     writeFileSync(join(dir, ".last-seen-version"), "0.1.0");

--- a/scripts/update-notice.ts
+++ b/scripts/update-notice.ts
@@ -111,10 +111,7 @@ if (!isStaticMode()) {
         readFileSync(
           join(
             PLUGIN_DIR,
-            "..",
-            "..",
-            "..",
-            "..",
+            "../../../..",
             "marketplaces",
             marketplaceName,
             ".claude-plugin",
@@ -146,16 +143,26 @@ if (!isStaticMode()) {
     // A state directory that has never recorded a version (a first-ever run,
     // or an existing user updating past the point this file started being
     // written) only sees the latest entry, not the whole history.
+    // slice(0, 1), NOT slice(-1): CHANGELOG is newest-first, so the tail is
+    // the OLDEST entry. That mismatch shipped a first-run notice headed
+    // "updated to v0.20.0" with v0.18.0's bullets under it.
     const newEntries = lastSeen
       ? CHANGELOG.filter((e) => newer(e.version, lastSeen))
-      : CHANGELOG.slice(-1);
+      : CHANGELOG.slice(0, 1);
     const notes = newEntries.flatMap((e) => e.notes);
-    sections.push(
-      `WhatsApp plugin updated to v${PLUGIN_VERSION}` +
-        (lastSeen ? ` (from v${lastSeen})` : "") +
-        `.\n\nWhat's new:\n` +
-        notes.map((n) => `- ${n}`).join("\n"),
-    );
+    // No entries means nothing truthful to say. A downgrade lands here -
+    // lastSeen is NEWER than what is running, so the filter matches nothing -
+    // and the header would claim an update that did not happen, over an empty
+    // list, with the model told to relay it. The marker write below stays
+    // unconditional so the downgrade is still recorded.
+    if (notes.length > 0) {
+      sections.push(
+        `WhatsApp plugin updated to v${PLUGIN_VERSION}` +
+          (lastSeen ? ` (from v${lastSeen})` : "") +
+          `.\n\nWhat's new:\n` +
+          notes.map((n) => `- ${n}`).join("\n"),
+      );
+    }
   }
 
   // Deliberately NOT gated on the marker. The "what's new" notice above gets

--- a/scripts/update-notice.ts
+++ b/scripts/update-notice.ts
@@ -57,12 +57,18 @@ if (!isStaticMode()) {
   // latest.
   const CHANGELOG: { version: string; notes: string[] }[] = [
     {
-      version: "0.20.0",
+      version: "0.21.0",
       notes: [
         `The guided setup wizard can now take access back, not just hand it out: \`${WIZARD_CMD} --revoke\` lists everything currently configured and you tick what should lose access. Leaving everything unticked removes nothing.`,
         "You will now be told when a newer version of this plugin is available, instead of only hearing about one after you had already installed it. Notices like this one now print straight to your terminal rather than being passed to the assistant and hoping it mentions them.",
-        "`/whatsapp-claude-channel:access` with no arguments now ends by telling you how to add groups and contacts, how to take access back, and how to do either with no AI model involved.",
+        "`/whatsapp-channel:access` with no arguments now ends by telling you how to add groups and contacts, how to take access back, and how to do either with no AI model involved.",
         "Fixed: the WA:<role> statusline segment never appeared. It was looking for the server in the wrong branch of the process tree, and failing silently when it did not find it. Each server now records which session it belongs to, so with several sessions open every terminal shows its own role rather than possibly a neighbour's.",
+      ],
+    },
+    {
+      version: "0.20.0",
+      notes: [
+        "The plugin was renamed from `whatsapp-claude-channel` to `whatsapp-channel`, so its commands are now `/whatsapp-channel:access`, `/whatsapp-channel:configure` and so on. An install under the old name keeps working but stops receiving updates - reinstall with `/plugin install whatsapp-channel@whatsapp-claude-plugin` to keep getting them.",
       ],
     },
     {

--- a/scripts/update-notice.ts
+++ b/scripts/update-notice.ts
@@ -1,8 +1,19 @@
 #!/usr/bin/env bun
 /**
- * Prints the SessionStart hook's one-time "what's new" notice to stdout as
- * a complete, ready-to-emit JSON object, or nothing at all if there's
- * nothing new. Also advances .last-seen-version when it prints one.
+ * Prints the SessionStart hook's notice to stdout as a complete,
+ * ready-to-emit JSON object, or nothing at all if there's nothing to say.
+ *
+ * Two different notices, and the difference matters:
+ *   - "what's new"  — this install just changed version. One-time, gated on
+ *                     .last-seen-version, which this script advances.
+ *   - "update available" — a NEWER version exists that the user has not
+ *                     installed. Not gated on anything: it repeats every
+ *                     session until they actually update, and stops by
+ *                     itself when they do.
+ *
+ * The second one is issue #2. The first can only ever announce a version the
+ * user ALREADY has (it reads this plugin's own plugin.json), so on its own
+ * the plugin could never tell anyone an update was waiting.
  *
  * Invoked by hooks-handlers/session-start.sh once setup is fully
  * configured — a version bump is a session-start-shaped file check,
@@ -13,7 +24,7 @@
  */
 import { readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { wizardCmd } from "./wizard-cmd";
 
 const STATE_DIR =
@@ -46,6 +57,14 @@ if (!isStaticMode()) {
   // latest.
   const CHANGELOG: { version: string; notes: string[] }[] = [
     {
+      version: "0.20.0",
+      notes: [
+        `The guided setup wizard can now take access back, not just hand it out: \`${WIZARD_CMD} --revoke\` lists everything currently configured and you tick what should lose access. Leaving everything unticked removes nothing.`,
+        "You will now be told when a newer version of this plugin is available, instead of only hearing about one after you had already installed it.",
+        "Fixed: the WA:<role> statusline segment never appeared. It was looking for the server in the wrong branch of the process tree, and failing silently when it did not find it.",
+      ],
+    },
+    {
       version: "0.19.0",
       notes: [
         "Access review now works without leaving the chat: `/whatsapp-channel:access review` shows a checkbox list of your most recently active groups and contacts to approve, and `manage` shows what is already approved so you can take it back. The terminal wizard is still there when you want a decision made with no AI model in the room.",
@@ -60,36 +79,105 @@ if (!isStaticMode()) {
     },
   ];
 
-  const PLUGIN_VERSION: string = JSON.parse(
-    readFileSync(
-      join(import.meta.dir, "..", ".claude-plugin", "plugin.json"),
-      "utf8",
-    ),
-  ).version;
+  const PLUGIN_DIR = join(import.meta.dir, "..");
+  const MANIFEST = JSON.parse(
+    readFileSync(join(PLUGIN_DIR, ".claude-plugin", "plugin.json"), "utf8"),
+  );
+  const PLUGIN_VERSION: string = MANIFEST.version;
+  const PLUGIN_NAME: string = MANIFEST.name;
+
+  // Numeric collation, so "0.18.0" > "0.9.0" instead of the plain string
+  // compare that gets any double-digit segment backwards. Shared by both
+  // notices below.
+  const newer = (a: string, b: string): boolean =>
+    a.localeCompare(b, undefined, { numeric: true }) > 0;
+
+  // What the marketplace this plugin came from currently advertises, versus
+  // what is actually running here. Both halves are already on disk and
+  // Claude Code refreshes the marketplace clone itself, so no network call:
+  //
+  //   <plugins>/cache/<marketplace>/<plugin>/<version>/   <- PLUGIN_DIR
+  //   <plugins>/marketplaces/<marketplace>/.claude-plugin/marketplace.json
+  //
+  // Derived from this script's own location rather than hardcoded, so it
+  // holds for every profile and install path. A repo checkout has neither
+  // path, and an install laid out some other way simply misses - in both
+  // cases this returns null and says nothing, which is the right failure for
+  // something that runs on every session start.
+  function availableVersion(): string | null {
+    try {
+      const marketplaceName = basename(join(PLUGIN_DIR, "..", ".."));
+      const parsed = JSON.parse(
+        readFileSync(
+          join(
+            PLUGIN_DIR,
+            "..",
+            "..",
+            "..",
+            "..",
+            "marketplaces",
+            marketplaceName,
+            ".claude-plugin",
+            "marketplace.json",
+          ),
+          "utf8",
+        ),
+      );
+      const entries: { name?: string; version?: string }[] =
+        parsed.plugins ?? [];
+      // By name, not entries[0]: a marketplace is free to list several
+      // plugins, and the first one is not necessarily this one.
+      const mine = entries.find((e) => e.name === PLUGIN_NAME);
+      return mine?.version ?? null;
+    } catch {
+      return null;
+    }
+  }
 
   let lastSeen = "";
   try {
     lastSeen = readFileSync(LAST_SEEN_VERSION_FILE, "utf8").trim();
   } catch {}
 
-  if (lastSeen !== PLUGIN_VERSION) {
-    // "0.18.0" > "0.9.0" needs numeric collation, not a plain string
-    // compare (which gets any double-digit segment backwards). A state
-    // directory that has never recorded a version (a first-ever run, or an
-    // existing user updating past the point this file started being
+  const sections: string[] = [];
+
+  const changedVersion = lastSeen !== PLUGIN_VERSION;
+  if (changedVersion) {
+    // A state directory that has never recorded a version (a first-ever run,
+    // or an existing user updating past the point this file started being
     // written) only sees the latest entry, not the whole history.
     const newEntries = lastSeen
-      ? CHANGELOG.filter(
-          (e) =>
-            e.version.localeCompare(lastSeen, undefined, { numeric: true }) > 0,
-        )
+      ? CHANGELOG.filter((e) => newer(e.version, lastSeen))
       : CHANGELOG.slice(-1);
     const notes = newEntries.flatMap((e) => e.notes);
-    const content =
+    sections.push(
       `WhatsApp plugin updated to v${PLUGIN_VERSION}` +
-      (lastSeen ? ` (from v${lastSeen})` : "") +
-      `.\n\nWhat's new:\n` +
-      notes.map((n) => `- ${n}`).join("\n");
+        (lastSeen ? ` (from v${lastSeen})` : "") +
+        `.\n\nWhat's new:\n` +
+        notes.map((n) => `- ${n}`).join("\n"),
+    );
+  }
+
+  // Deliberately NOT gated on the marker. The "what's new" notice above gets
+  // exactly one session to land, because the marker advances right after it;
+  // this one repeats every session until the user actually updates, and goes
+  // quiet on its own the moment they do. A missed delivery is therefore
+  // retried instead of lost, which is the other half of issue #2.
+  const available = availableVersion();
+  if (available && newer(available, PLUGIN_VERSION)) {
+    sections.push(
+      `A newer WhatsApp plugin is available: v${available} (this session is running v${PLUGIN_VERSION}).\n` +
+        `To get it: \`claude plugin update ${PLUGIN_NAME}\`, then restart the session - the running one keeps the old copy until then.`,
+    );
+  }
+
+  if (sections.length > 0) {
+    // SessionStart output reaches the MODEL, not the user's screen, so a
+    // notice that is not relayed is a notice nobody read. Say so explicitly
+    // rather than hoping it gets mentioned.
+    const content =
+      "Tell the user the following in your next message - it is a notice for them, not background context for you:\n\n" +
+      sections.join("\n\n");
     process.stdout.write(
       JSON.stringify({
         hookSpecificOutput: {
@@ -98,6 +186,9 @@ if (!isStaticMode()) {
         },
       }),
     );
+  }
+
+  if (changedVersion) {
     // Written unconditionally whenever the version changed, even if this
     // particular bump turned up no CHANGELOG entry (an odd but possible
     // state, e.g. a downgrade) - otherwise the marker never advances and

--- a/scripts/update-notice.ts
+++ b/scripts/update-notice.ts
@@ -63,6 +63,7 @@ if (!isStaticMode()) {
         "You will now be told when a newer version of this plugin is available, instead of only hearing about one after you had already installed it. Notices like this one now print straight to your terminal rather than being passed to the assistant and hoping it mentions them.",
         "`/whatsapp-channel:access` with no arguments now ends by telling you how to add groups and contacts, how to take access back, and how to do either with no AI model involved.",
         "Fixed: the WA:<role> statusline segment never appeared. It was looking for the server in the wrong branch of the process tree, and failing silently when it did not find it. Each server now records which session it belongs to, so with several sessions open every terminal shows its own role rather than possibly a neighbour's.",
+        "Fixed: leftover `.role-<pid>` files from crashed or killed sessions are now cleared at startup instead of piling up in `~/.whatsapp-channel/` forever.",
       ],
     },
     {

--- a/scripts/update-notice.ts
+++ b/scripts/update-notice.ts
@@ -60,7 +60,8 @@ if (!isStaticMode()) {
       version: "0.20.0",
       notes: [
         `The guided setup wizard can now take access back, not just hand it out: \`${WIZARD_CMD} --revoke\` lists everything currently configured and you tick what should lose access. Leaving everything unticked removes nothing.`,
-        "You will now be told when a newer version of this plugin is available, instead of only hearing about one after you had already installed it.",
+        "You will now be told when a newer version of this plugin is available, instead of only hearing about one after you had already installed it. Notices like this one now print straight to your terminal rather than being passed to the assistant and hoping it mentions them.",
+        "`/whatsapp-claude-channel:access` with no arguments now ends by telling you how to add groups and contacts, how to take access back, and how to do either with no AI model involved.",
         "Fixed: the WA:<role> statusline segment never appeared. It was looking for the server in the wrong branch of the process tree, and failing silently when it did not find it.",
       ],
     },
@@ -179,18 +180,31 @@ if (!isStaticMode()) {
   }
 
   if (sections.length > 0) {
-    // SessionStart output reaches the MODEL, not the user's screen, so a
-    // notice that is not relayed is a notice nobody read. Say so explicitly
-    // rather than hoping it gets mentioned.
-    const content =
-      "Tell the user the following in your next message - it is a notice for them, not background context for you:\n\n" +
-      sections.join("\n\n");
+    // systemMessage, NOT hookSpecificOutput.additionalContext (issue #5).
+    // additionalContext is the channel for things the MODEL needs to know: it
+    // is folded into the session context, costs input tokens every time it
+    // fires, and reaches the human only if the model chooses to mention it.
+    // This is a notice FOR the human and of no use to the model, so it goes
+    // on the channel that shows it to them - which also means no "please
+    // relay this" preamble, the workaround that channel forced.
+    //
+    // The caller passes its own model-facing message through as argv[2],
+    // because printing this notice REPLACES the handler's whole JSON output.
+    // Carrying it here rather than restating it means the session that sees a
+    // notice still briefs the model exactly like every other session, and the
+    // wording lives in one place (hooks-handlers/session-start.sh).
+    const modelContext = process.argv[2];
     process.stdout.write(
       JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "SessionStart",
-          additionalContext: content,
-        },
+        systemMessage: sections.join("\n\n"),
+        ...(modelContext
+          ? {
+              hookSpecificOutput: {
+                hookEventName: "SessionStart",
+                additionalContext: modelContext,
+              },
+            }
+          : {}),
       }),
     );
   }

--- a/scripts/update-notice.ts
+++ b/scripts/update-notice.ts
@@ -62,7 +62,7 @@ if (!isStaticMode()) {
         `The guided setup wizard can now take access back, not just hand it out: \`${WIZARD_CMD} --revoke\` lists everything currently configured and you tick what should lose access. Leaving everything unticked removes nothing.`,
         "You will now be told when a newer version of this plugin is available, instead of only hearing about one after you had already installed it. Notices like this one now print straight to your terminal rather than being passed to the assistant and hoping it mentions them.",
         "`/whatsapp-claude-channel:access` with no arguments now ends by telling you how to add groups and contacts, how to take access back, and how to do either with no AI model involved.",
-        "Fixed: the WA:<role> statusline segment never appeared. It was looking for the server in the wrong branch of the process tree, and failing silently when it did not find it.",
+        "Fixed: the WA:<role> statusline segment never appeared. It was looking for the server in the wrong branch of the process tree, and failing silently when it did not find it. Each server now records which session it belongs to, so with several sessions open every terminal shows its own role rather than possibly a neighbour's.",
       ],
     },
     {

--- a/server.ts
+++ b/server.ts
@@ -97,8 +97,10 @@ const TASKS_FILE = join(STATE_DIR, "tasks.md");
 const LOCK_FILE = join(STATE_DIR, ".server.lock");
 const IPC_TOKEN_FILE = join(STATE_DIR, ".ipc-token");
 // Read by scripts/statusline-role.ts. PID-scoped so two terminals never
-// collide on one file; a stale one from a dead process is harmless, the
-// reader only ever looks up a pid it just found alive in the process list.
+// collide on one file. A stale one from a dead process cannot be misread -
+// the reader matches on the owning session stamped inside, and a dead pid is
+// nobody's ancestor - but it is still swept at startup, see
+// sweepStaleRoleFiles.
 const ROLE_FILE = join(STATE_DIR, `.role-${process.pid}`);
 // resolve(): two terminals can pass the same directory spelled differently
 // (trailing separator, relative path) and ipcSocketPath hashes the raw
@@ -248,6 +250,31 @@ function pidAlive(pid: number): boolean {
     return (err as NodeJS.ErrnoException).code === "EPERM";
   }
 }
+
+// shutdown() removes this process's own role file, but only on a graceful
+// exit - stdin close, SIGTERM, SIGINT. A SIGKILL, a crash, an OOM kill or a
+// power loss all skip it by definition, and nothing else ever looked at the
+// directory, so the files accumulated for the life of the install (issue #4:
+// six files for three live servers on one machine).
+//
+// Runs before the singleton lock is taken, so a process that goes on to
+// refuse and exit still tidies up on its way through. Deleting another
+// server's file is safe by construction: the pid is in the name, and a pid
+// that answers no signal has no process to be confused with.
+function sweepStaleRoleFiles(): void {
+  try {
+    for (const name of readdirSync(STATE_DIR)) {
+      if (!name.startsWith(".role-")) continue;
+      const pid = Number(name.slice(".role-".length));
+      // A name that is not .role-<number> is not ours to delete.
+      if (!Number.isInteger(pid) || pid <= 0 || pidAlive(pid)) continue;
+      try {
+        rmSync(join(STATE_DIR, name), { force: true });
+      } catch {}
+    }
+  } catch {}
+}
+sweepStaleRoleFiles();
 
 // Who holds the connection when we cannot. `client` is the CLAUDE_PID the
 // holder recorded, "" when started by something that does not set one.

--- a/server.ts
+++ b/server.ts
@@ -381,7 +381,14 @@ function writeRoleFile(
   everConnected = false,
 ): void {
   try {
-    writeFileSync(ROLE_FILE, role);
+    // Line 1 is the role, unchanged, so any older reader keeps working.
+    // Line 2 stamps the Claude Code session that owns this server, when it
+    // told us (CLIENT_ID is CLAUDE_PID). The statusline used to infer
+    // ownership by walking the process tree, which cannot distinguish this
+    // terminal's server from a sibling terminal's once a shared ancestor is
+    // in range - it would show someone else's role as yours. Stamped, the
+    // reader just checks whether the owner is one of its own ancestors.
+    writeFileSync(ROLE_FILE, CLIENT_ID ? `${role}\n${CLIENT_ID}\n` : role);
   } catch {}
   if (pastInitialRole) notifyRoleChange(role, everConnected);
   pastInitialRole = true;

--- a/skills/access/SKILL.md
+++ b/skills/access/SKILL.md
@@ -225,10 +225,12 @@ themselves (a marketplace install's real path — not the repo-relative
 `scripts/access.ts`, which resolves to nothing outside a repo checkout).
 Continue helping with everything else in this skill as normal.
 
-`wizard` is the ONLY subcommand of that script you may not run. The `review`
-and `manage` flows below do run it, for `candidates`, `configured`, `allow`,
-`remove`, `group add` and `group rm` — none of which is interactive, and
-none of which decides anything on its own.
+The same applies to `wizard --revoke`, its revoke screen: same terminal-only
+guarantee, same refusal here. `wizard` in either mode is the ONLY subcommand
+of that script you may not run. The `review` and `manage` flows below do run
+it, for `candidates`, `configured`, `allow`, `remove`, `group add` and
+`group rm` — none of which is interactive, and none of which decides
+anything on its own.
 
 ### Running `access.ts` from `review` and `manage`
 
@@ -447,7 +449,8 @@ The CLI also has one command this skill deliberately does not implement:
 `bun "${CLAUDE_PLUGIN_ROOT}/scripts/access.ts" wizard`, a checkbox screen (arrow keys + space +
 enter) over the account's 5 most recently active groups and 10 most
 recently active DM contacts, so review stays to one screen each instead
-of scaling with how many groups/contacts exist. It's terminal-only by
+of scaling with how many groups/contacts exist. Its `--revoke` mode is the
+same screen over everything already configured, uncapped. It's terminal-only by
 design (see the `wizard` entry above) so the decision can be made with a
 verifiable guarantee that no AI model was involved in making it. Point
 the user at it for setting up several groups or contacts at once; use

--- a/skills/access/SKILL.md
+++ b/skills/access/SKILL.md
@@ -68,13 +68,18 @@ Parse `$ARGUMENTS` (space-separated). If empty or unrecognized, show status.
    sender IDs + age, groups count.
 3. End with the three things a person can do next. Nothing else advertises
    them: a release note is seen once at most, and someone who has not read
-   one cannot guess the word `review`. Print exactly:
+   one cannot guess the word `review`. Print these three:
 
    - Add groups or contacts: `/whatsapp-claude-channel:access review`
    - Take access back: `/whatsapp-claude-channel:access manage`
-   - Same screens with no AI model involved: run
-     `bun "${CLAUDE_PLUGIN_ROOT}/scripts/access.ts" wizard` (or
+   - Same screens with no AI model involved: run the wizard (or
      `wizard --revoke`) in your own terminal
+
+   In that last line write the **resolved absolute path** to
+   `scripts/access.ts`, never the literal `${CLAUDE_PLUGIN_ROOT}` — Claude
+   Code substitutes that variable, a user's shell does not, so pasting it
+   verbatim runs `bun "/scripts/access.ts"` and fails. Same rule as the
+   `wizard` section below.
 
    Do not run any of them off the back of showing this list — it is a
    signpost, not a prompt. Wait for the user to pick.

--- a/skills/access/SKILL.md
+++ b/skills/access/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: access
-description: Manage WhatsApp channel access — approve pairings, edit allowlists, set DM/group policy. Use when the user asks to pair, approve someone, check who's allowed, or change policy for the WhatsApp channel.
+description: Manage WhatsApp channel access — approve pairings, edit allowlists, set DM/group policy. Use when the user asks to pair, approve someone, check who's allowed, or change policy for the WhatsApp channel, and equally when they ask to add contacts or groups, set up or bulk-approve access, or take someone's access away — those are this skill's `review` and `manage` screens, not something to hand-edit.
 user-invocable: true
 allowed-tools:
   - Read
@@ -66,6 +66,18 @@ Parse `$ARGUMENTS` (space-separated). If empty or unrecognized, show status.
 1. Read `~/.whatsapp-channel/access.json` (handle missing file).
 2. Show: dmPolicy, allowFrom count and list, pending count with codes +
    sender IDs + age, groups count.
+3. End with the three things a person can do next. Nothing else advertises
+   them: a release note is seen once at most, and someone who has not read
+   one cannot guess the word `review`. Print exactly:
+
+   - Add groups or contacts: `/whatsapp-claude-channel:access review`
+   - Take access back: `/whatsapp-claude-channel:access manage`
+   - Same screens with no AI model involved: run
+     `bun "${CLAUDE_PLUGIN_ROOT}/scripts/access.ts" wizard` (or
+     `wizard --revoke`) in your own terminal
+
+   Do not run any of them off the back of showing this list — it is a
+   signpost, not a prompt. Wait for the user to pick.
 
 ### `pair <code>`
 

--- a/skills/access/SKILL.md
+++ b/skills/access/SKILL.md
@@ -70,8 +70,8 @@ Parse `$ARGUMENTS` (space-separated). If empty or unrecognized, show status.
    them: a release note is seen once at most, and someone who has not read
    one cannot guess the word `review`. Print these three:
 
-   - Add groups or contacts: `/whatsapp-claude-channel:access review`
-   - Take access back: `/whatsapp-claude-channel:access manage`
+   - Add groups or contacts: `/whatsapp-channel:access review`
+   - Take access back: `/whatsapp-channel:access manage`
    - Same screens with no AI model involved: run the wizard (or
      `wizard --revoke`) in your own terminal
 


### PR DESCRIPTION
Three issues I hit running the plugin day to day, plus three more turned up
on the way - two by code review, one by clearing the mess off my own machine. Rebased on top of the `whatsapp-channel` rename, so this
takes **0.21.0** — 0.20.0 is the rename itself.

## The three

**1. `WA:<role>` statusline segment never rendered** (since it landed in #18).
`statusline-role.ts` derived `PARENT_PID` from `process.ppid` and searched
*downward*. A `statusLine` setting is a compound command, so the script runs
under a shell the CLI spawned separately — a **sibling** of the plugin wrapper,
not an ancestor. The search could never reach it, and the miss is silent by
design, so it failed quietly for two days. It now climbs the ppid chain
(bounded, nearest-first) before searching down.

Two things surfaced while fixing it:

- The wrapper is matched on the plugin dir name, and the documented statusLine
  command *contains that name* (`bun <plugin-dir>/scripts/statusline-role.ts`).
  The shell was matching the wrapper pattern at the same BFS depth as the real
  wrapper, and a first-match search picked whichever row Win32_Process happened
  to list first. That turned a permanent failure into an intermittent one.
  Every candidate is now tried, and the one with a `server.ts` under it wins.
- Even fixed, a process-tree walk cannot tell this terminal's server from a
  sibling terminal's once a shared ancestor is in range — it would show
  someone else's role as yours. So `server.ts` now stamps the owning session
  (`CLAUDE_PID`) as line 2 of its role file, and the statusline takes the file
  whose owner is one of its own ancestors. Ownership is read, not inferred.
  Line 1 is unchanged, so older readers still work, and a server that has not
  restarted falls back to the tree walk.

  Side effect: a stale `.role-<pid>` from a crashed session can no longer be
  picked up, because a dead process is nobody's ancestor.

**2. The update notice had no second chance, and could only announce the past.**
It was emitted as `hookSpecificOutput.additionalContext` — the model's channel
— while `.last-seen-version` advanced unconditionally right after. If the model
did not relay it that one session, nobody ever saw it. And because it read this
plugin's own `plugin.json`, it could only ever say "you updated", never "an
update is waiting".

- Notices now ride on `systemMessage`, which goes to the user's terminal. No
  tokens, no dependence on the model repeating it, no "please relay this"
  preamble.
- A separate "newer version available" notice compares the running version
  against what the marketplace clone advertises (both already on disk, no
  network call). Deliberately **not** marker-gated, so it repeats until the
  user actually updates and goes quiet by itself when they do.
- The hook passes its own model-facing message through, so a session that gets
  a notice still briefs the model identically to one that does not.

**3. `wizard --revoke`.** The wizard could grant access but never take it back;
the only paths were `remove <jid>` one at a time or hand-editing `access.json`.
The revoke screen reuses `listConfiguredGroups`/`listConfiguredDms` — the same
functions the in-session `manage` reads through `configured` — so the terminal
and the chat cannot disagree about what is configured or how a row is labelled.
Empty selection removes nothing, and the cache rule is extracted to
`revokeCachedIdentity()` and shared with `remove` so the two cannot drift.

## The three found along the way

**A first-run notice showed the oldest release notes.** `CHANGELOG.slice(-1)`
takes the tail, but the array is newest-first — so a fresh install got a header
saying the current version over the *first* release's bullets. This is what bit
me: I was told about the wizard on an install that already had it. Now
`slice(0, 1)`, with a test pinning the head entry to the shipping version so
the next release cannot reintroduce it.

**A downgrade announced an update that never happened.** `changedVersion` was
true while the version filter matched nothing, emitting "updated to v0.20.0
(from v0.99.0)" over an empty list. Guarded on `notes.length > 0`; the marker
write stays unconditional.

**Stale `.role-<pid>` files accumulated forever.** `shutdown()` removes this
process's own role file, but it is only reached from stdin close, `SIGTERM`
and `SIGINT` - a `SIGKILL`, crash, OOM kill or power loss skips it, and
nothing swept the directory. My machine had six files for three live servers.
`server.ts` now sweeps role files whose pid answers no signal, before the
singleton lock is taken, so even a process that goes on to refuse and exit
tidies up on its way through. A live pid's file is never touched, and a name
that is not `.role-<number>` is left alone.

## Discovery

`review`, `manage` and `wizard --revoke` were reachable only by someone who
already knew their names — and the notice that would have told them was the
unreliable one above. `/whatsapp-channel:access` with no arguments now ends by
naming all three, and the skill description covers "add contacts", "add
groups", "bulk approve" so the phrasings people actually use trigger it.

## One thing to flag

The rename shipped without a CHANGELOG entry, so someone updating from 0.19.0
gets no word that the plugin renamed or that their old install stops receiving
updates. Since this PR is about exactly that failure, I wrote the 0.20.0 entry
for it — happy to drop that hunk if you would rather word it yourself.

## Checks

`bun test` — **298 pass, 13 skip, 0 fail**. Prettier clean on every file
touched; no new markdown fences, so no MD040. The statusline fix is verified
live on my machine (the old script printed nothing, the new one prints a green
`WA:primary`), and the new tests were each confirmed to fail against the
pre-fix source before being kept.

Not verified: that `systemMessage` renders in the terminal. The field is real
(size-capped separately in the CLI, counted separately in telemetry) and the
hook emits it correctly, but I have not watched a client display it.
