### PR TITLE
drop role files whose server pid is gone, since only a clean exit removes one

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "whatsapp-channel",
       "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control, pairing, allowlists, and group policy.",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "source": "./",
       "category": "channels"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "whatsapp-channel",
   "displayName": "WhatsApp Channel for Claude Code",
   "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /whatsapp-channel:access.",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "author": {
     "name": "Rich627"
   },

--- a/scripts/statusline-role.test.ts
+++ b/scripts/statusline-role.test.ts
@@ -107,11 +107,16 @@ describe("end-to-end (real processes)", () => {
   // The stamped path, end to end through the real script: no wrapper and no
   // server process exist here at all, so this can only pass by reading the
   // owner pid out of the file. The decoy is a second terminal's server, which
-  // the process tree alone would have no way to rule out.
+  // the process tree alone would have no way to rule out. Both filenames use
+  // live pids (this test and its parent) so the liveness filter cannot be
+  // what decides it - the stamp has to.
   test("reads the stamped owner instead of hunting the process tree", () => {
     const dir = freshStateDir();
-    writeFileSync(join(dir, ".role-4242"), `secondary\n${process.pid}\n`);
-    writeFileSync(join(dir, ".role-4243"), "primary\n999999\n");
+    writeFileSync(
+      join(dir, `.role-${process.pid}`),
+      `secondary\n${process.pid}\n`,
+    );
+    writeFileSync(join(dir, `.role-${process.ppid}`), "primary\n999999\n");
     const out = runStatusline(
       dir,
       process.pid,
@@ -122,12 +127,27 @@ describe("end-to-end (real processes)", () => {
     expect(out).not.toContain("primary");
   });
 
+  // A server that was killed without a graceful exit leaves its role file
+  // behind, and the owning session named on line 2 is still alive and still
+  // an ancestor - so the stamp alone would happily print a role for a server
+  // that no longer exists. The filename's pid is dead, which is the only
+  // thing that gives it away.
+  test("ignores a stamped file whose server is gone", () => {
+    const dir = freshStateDir();
+    writeFileSync(join(dir, ".role-999999"), `secondary\n${process.pid}\n`);
+    expect(
+      runStatusline(dir, process.pid, "no-such-wrapper", "no-such-server"),
+    ).toBe("");
+  });
+
   // Same fixture minus the stamp: nothing matches, and with no wrapper or
   // server process to fall back to the script stays silent rather than
   // picking the only file it can see.
+  // Live server pid on purpose, so the silence is the owner mismatch talking
+  // and not the liveness filter above.
   test("stays silent when the only files belong to someone else", () => {
     const dir = freshStateDir();
-    writeFileSync(join(dir, ".role-4243"), "primary\n999999\n");
+    writeFileSync(join(dir, `.role-${process.pid}`), "primary\n999999\n");
     expect(
       runStatusline(dir, process.pid, "no-such-wrapper", "no-such-server"),
     ).toBe("");

--- a/scripts/statusline-role.ts
+++ b/scripts/statusline-role.ts
@@ -13,6 +13,8 @@
  *    it as line 2 of its role file, so we climb our own ppid chain and take
  *    the file whose owner is one of our ancestors. Ownership is read, not
  *    guessed, so a sibling terminal's server can never be mistaken for ours.
+ *    Files whose server pid (from the filename) is no longer running are
+ *    dropped first, so a killed server's file cannot keep printing a role.
  * 2. The process tree, for a server that predates the stamp or a client that
  *    never identified itself: climb the ppid chain to the Claude Code CLI
  *    (this script does NOT run as its direct child — see
@@ -263,12 +265,21 @@ export function formatSegment(role: string): string {
   return color ? `${color}WA:${role}${RESET}` : "";
 }
 
-// Every role file in the state dir. Missing dir, unreadable file, no files
-// at all: an empty list, same as every other miss in here.
-function readRoleFiles(): string[] {
+// Every role file in the state dir whose server is still running. Missing
+// dir, unreadable file, no files at all: an empty list, same as every other
+// miss in here.
+//
+// The liveness filter is what stops a stamped file outliving its server:
+// only a graceful exit removes one, so a killed server leaves a file whose
+// owning session is still alive and still our ancestor, and the stamp would
+// keep printing a role for a server that is gone. server.ts's startup sweep
+// cannot cover it - nothing starts. A non-numeric name is not in the set
+// either and drops out the same way.
+function readRoleFiles(livePids: Set<number>): string[] {
   try {
     return readdirSync(STATE_DIR)
       .filter((f) => f.startsWith(".role-"))
+      .filter((f) => livePids.has(Number(f.slice(".role-".length))))
       .map((f) => {
         try {
           return readFileSync(join(STATE_DIR, f), "utf8");
@@ -289,7 +300,10 @@ function main(): void {
     // server that has not been restarted since this shipped, or a client that
     // does not identify itself - it can confuse a sibling terminal's server
     // for ours, which is exactly what the stamp exists to prevent.
-    const stamped = roleFromOwnerStamp(readRoleFiles(), ancestors);
+    const stamped = roleFromOwnerStamp(
+      readRoleFiles(new Set(rows.map((r) => r.pid))),
+      ancestors,
+    );
     if (stamped) {
       const segment = formatSegment(stamped);
       if (segment) process.stdout.write(segment);

--- a/scripts/update-notice.test.ts
+++ b/scripts/update-notice.test.ts
@@ -68,10 +68,26 @@ describe("update-notice.ts", () => {
   // and shipped a notice headed with the current version over notes from the
   // first release in the file. The test above asserts only the header, which
   // is exactly why that went unnoticed.
+  //
+  // The head note is read out of the source rather than pasted in, so this
+  // keeps testing the slice direction instead of needing an edit every time
+  // a release adds an entry — which is what it used to need, and what would
+  // tempt the next person to "fix" it by pasting the new text in.
   test("first-ever run shows the NEWEST changelog entry, not the oldest", () => {
+    const source = readFileSync(join(import.meta.dir, "update-notice.ts"), {
+      encoding: "utf8",
+    });
+    // First string literal of at least 30 plain characters after the first
+    // `notes: [` — i.e. the head entry's first note. Literals carrying a
+    // ${...} interpolation are skipped: the source text and the rendered
+    // output differ there, so they cannot be compared against the notice.
+    const headNote = source
+      .slice(source.indexOf("notes: ["))
+      .match(/["`]([^"`$]{30,})/)?.[1];
+    expect(headNote).toBeTruthy();
     const dir = mkdtempSync(join(tmpdir(), "wa-notice-newest-"));
     const ctx = JSON.parse(run(dir)).systemMessage as string;
-    expect(ctx).toContain("--revoke");
+    expect(ctx).toContain(headNote!.slice(0, 40));
     expect(ctx).not.toContain("Proactive notifications");
   });
 

--- a/scripts/update-notice.ts
+++ b/scripts/update-notice.ts
@@ -57,6 +57,12 @@ if (!isStaticMode()) {
   // latest.
   const CHANGELOG: { version: string; notes: string[] }[] = [
     {
+      version: "0.21.1",
+      notes: [
+        "Fixed: the WA:<role> statusline segment could keep showing a role after its server had been killed, because the file it reads is only removed on a clean shutdown. It now checks the server is still running before believing the file.",
+      ],
+    },
+    {
       version: "0.21.0",
       notes: [
         `The guided setup wizard can now take access back, not just hand it out: \`${WIZARD_CMD} --revoke\` lists everything currently configured and you tick what should lose access. Leaving everything unticked removes nothing.`,


### PR DESCRIPTION
The follow-up you asked for in #26: a stamped role file outliving its server.

## The bug

`roleFromOwnerStamp` matches on the owner pid on line 2 and never checks the
server pid in the filename. Kill a server without a graceful exit and never
restart it, and the file stays: the owning session is still alive, still an
ancestor, so the statusline keeps printing `WA:primary` for a server that
isn't there. The old tree walk went blank in that case, which was at least
honest.

The startup sweep can't cover it — that runs when a server *starts*, and here
nothing starts.

## The fix

Exactly where you pointed: `readRoleFiles` already has the filename and
`main()` already holds the process list, so it takes the live pid set and
drops any `.role-<pid>` that isn't in it. One `.filter`, no new process
scan. A non-numeric name isn't in the set either and drops out the same way —
this script only ever declines to believe a file, it never unlinks one.

## Tests

- New: `ignores a stamped file whose server is gone` — dead server pid, live
  owner stamp, expects silence. Verified against pre-fix source, where it
  fails with `WA:secondary`.
- Two existing e2e fixtures used dead server pids (`.role-4242`, `.role-4243`)
  and would have started passing for the wrong reason. Both now use live pids,
  so the stamp is still what decides them, not the new filter.

`bun test`: 299 pass, 13 skip, 0 fail. Prettier clean on every touched file.

## Version and changelog

0.21.1 in both manifests, plus the matching CHANGELOG entry — without a bump
`plugin update` never fetches this, which is the silent no-op you check for
every time.

That entry broke `first-ever run shows the NEWEST changelog entry, not the
oldest`, which asserted on `"--revoke"` — 0.21.0's text. Any new head entry
would break it, and the tempting "fix" is to paste the new text in and leave
the same trap for the next release. It now derives the head note from the
source, the way the version-pairing test right below it already does. Verified
it still catches the original bug by flipping `slice(0, 1)` back to
`slice(-1)`.

Happy to drop the version bump into a separate commit or leave the release to
you if you'd rather cut 0.21.1 yourself.
