### PR TITLE
Fix #29 #30 #31 — resync backoff, stranger cache TTL, per-group context opt-out

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "whatsapp-channel",
       "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control, pairing, allowlists, and group policy.",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "source": "./",
       "category": "channels"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "whatsapp-channel",
   "displayName": "WhatsApp Channel for Claude Code",
   "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /whatsapp-channel:access.",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "author": {
     "name": "Rich627"
   },

--- a/ACCESS.md
+++ b/ACCESS.md
@@ -51,7 +51,7 @@ Groups are off by default. Opt each one in individually.
 
 Group JIDs end in `@g.us`. To find one, add the linked device to the group — the server logs the group JID when it receives a message from an unenabled group.
 
-With the default `requireMention: false`, the server responds to every message. Pass `--mention` to require @mention, or `--allow jid1,jid2` to restrict which members can trigger it. Pass `--roster` to also grant roster access (see below) — off by default, same as everything else.
+With the default `requireMention: false`, the server responds to every message. Pass `--mention` to require @mention, or `--allow jid1,jid2` to restrict which members can trigger it. Pass `--roster` to also grant roster access (see below) — off by default, same as everything else. Pass `--no-context` to keep a mention-gated group's unaddressed messages out of the local log entirely (see "Mention detection" below).
 
 Running `group add` again on an already-configured group **merges**, it doesn't start over: any flag you don't pass this time keeps whatever was already set. Adding `--roster` to a group that already has `--mention` on doesn't reset `--mention` back off — only the flags you actually pass change anything. To explicitly turn `--mention` or `--roster` back off (rather than just never setting them), pass `--no-mention` / `--no-roster` — passing both a flag and its negation at once is refused, not silently resolved one way.
 
@@ -85,7 +85,9 @@ Baileys 7 uses LID (Local Identifier) format alongside phone JIDs. The same pers
 
 With it off, name resolution and masking still work for the lifetime of the running server (built fresh each run from WhatsApp's own contact sync), it just isn't written to disk — so a restart starts blank again and the wizard's contact screen has nothing to rank. Either way, `WHATSAPP_ACCESS_MODE=static` disables this cache regardless of `WHATSAPP_CACHE_CONTACTS` — a static deployment can't be made to write local state by an env var. The recency cache the wizard ranks by (`dm-activity.json`) follows the same switch, since it's the same kind of per-sender data — including for a sender the access gate rejected, which is exactly what the opt-out is there for.
 
-Saved names sync on connect only when the cache holds no saved name at all (WhatsApp otherwise sends them just once, at linking); the server asks for the contact list again, logs a count (`address book synced: 3 saved name(s)` — never a name or number), and stops asking once one is cached. It never asks more than once every five minutes, and never runs with `WHATSAPP_CACHE_CONTACTS=0` or in static mode. After it, `contacts.json` holds the names of everyone saved on your phone, on your disk only. Chat-list order cannot be re-fetched, so the wizard ranks by the DM activity it has seen since.
+Saved names sync on connect only when the cache holds no saved name at all (WhatsApp otherwise sends them just once, at linking); the server asks for the contact list again, logs a count (`address book synced: 3 saved name(s)` — never a name or number), and stops asking once one is cached. It never asks more than once a day (tracked in `~/.whatsapp-channel/.addressbook-sync`, so a restart doesn't reset the clock), and never runs with `WHATSAPP_CACHE_CONTACTS=0` or in static mode. After it, `contacts.json` holds the names of everyone saved on your phone, on your disk only. Chat-list order cannot be re-fetched, so the wizard ranks by the DM activity it has seen since.
+
+Someone who merely messaged the account and was never approved doesn't sit in these caches forever: on the server's hourly prune, a `dm-activity.json` entry older than **90 days** is dropped unless its number is allowlisted (for a DM or any group), and a `contacts.json` entry with no saved name is dropped once it has neither an allowlist entry nor any activity younger than that. Saved names — your own phone's address book — never age out this way.
 
 **Names may reach the AI model; raw phone numbers should not.** When you ask Claude to reply and mention someone, it can use a saved name (`"Akash"`) instead of a number — that name is what appears in Claude's context. Anywhere a number would otherwise be shown to a human (an ambiguous-name error, `group_roster` for someone with no saved name) it's masked to the last 4 digits (`•••••5122`) before it's built into any string, not filtered afterward.
 
@@ -169,7 +171,7 @@ The `/whatsapp-channel:access` skill will point you at it if you ask for guided 
 
 ## Mention detection
 
-A message that does **not** trigger the server in such a group is still kept, text only, in `~/.whatsapp-channel/messages.jsonl` with `routed: false`, so `catch_up` can show you the room; it is never routed, notified or counted as unreplied (retention rules: [USAGE.md, "Your own replies"](./USAGE.md#your-own-replies)). Nothing is kept for a group that is not allowlisted or for a sender the group's own `allowFrom` rejects.
+A message that does **not** trigger the server in such a group is still kept, text only, in `~/.whatsapp-channel/messages.jsonl` with `routed: false`, so `catch_up` can show you the room; it is never routed, notified or counted as unreplied (retention rules: [USAGE.md, "Your own replies"](./USAGE.md#your-own-replies)). Nothing is kept for a group that is not allowlisted or for a sender the group's own `allowFrom` rejects. If you'd rather mention gating keep its stricter pre-0.22 meaning for a group — _nothing_ about the room is stored unless Claude was addressed — opt that group out with `group add <jid> --no-context` (`--context` turns it back on; a group that never set it keeps context, the 0.22.0 default). This is per group, because the trade is per group: context is what lets Claude draft a message that fits the conversation, and the people it stores are the group's other members.
 
 In groups with `requireMention: true`, any of the following triggers the server:
 
@@ -213,17 +215,17 @@ Two different notices, from the same script (`scripts/update-notice.ts`):
 
 ## Skill reference
 
-| Command                                                       | Effect                                                                                                                            |
-| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `/whatsapp-channel:access`                                    | Print current state: policy, allowlist, pending pairings, enabled groups.                                                         |
-| `/whatsapp-channel:access pair a4f91c`                        | Approve pairing code `a4f91c`. Adds the sender to `allowFrom` and sends a confirmation on WhatsApp.                               |
-| `/whatsapp-channel:access deny a4f91c`                        | Discard a pending code. The sender is not notified.                                                                               |
-| `/whatsapp-channel:access allow 886912345678@s.whatsapp.net`  | Add a JID directly.                                                                                                               |
-| `/whatsapp-channel:access remove 886912345678@s.whatsapp.net` | Remove from the allowlist.                                                                                                        |
-| `/whatsapp-channel:access policy allowlist`                   | Set `dmPolicy`. Values: `pairing`, `allowlist`, `disabled`.                                                                       |
-| `/whatsapp-channel:access group add 120363424405607157@g.us`  | Enable a group (merges into an existing entry). Flags: `--mention`/`--no-mention`, `--allow jid1,jid2`, `--roster`/`--no-roster`. |
-| `/whatsapp-channel:access group rm 120363424405607157@g.us`   | Disable a group.                                                                                                                  |
-| `/whatsapp-channel:access set ackReaction 👀`                 | Set a config key: `ackReaction`, `replyToMode`, `textChunkLimit`, `chunkMode`, `mentionPatterns`.                                 |
+| Command                                                       | Effect                                                                                                                                                        |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/whatsapp-channel:access`                                    | Print current state: policy, allowlist, pending pairings, enabled groups.                                                                                     |
+| `/whatsapp-channel:access pair a4f91c`                        | Approve pairing code `a4f91c`. Adds the sender to `allowFrom` and sends a confirmation on WhatsApp.                                                           |
+| `/whatsapp-channel:access deny a4f91c`                        | Discard a pending code. The sender is not notified.                                                                                                           |
+| `/whatsapp-channel:access allow 886912345678@s.whatsapp.net`  | Add a JID directly.                                                                                                                                           |
+| `/whatsapp-channel:access remove 886912345678@s.whatsapp.net` | Remove from the allowlist.                                                                                                                                    |
+| `/whatsapp-channel:access policy allowlist`                   | Set `dmPolicy`. Values: `pairing`, `allowlist`, `disabled`.                                                                                                   |
+| `/whatsapp-channel:access group add 120363424405607157@g.us`  | Enable a group (merges into an existing entry). Flags: `--mention`/`--no-mention`, `--allow jid1,jid2`, `--roster`/`--no-roster`, `--context`/`--no-context`. |
+| `/whatsapp-channel:access group rm 120363424405607157@g.us`   | Disable a group.                                                                                                                                              |
+| `/whatsapp-channel:access set ackReaction 👀`                 | Set a config key: `ackReaction`, `replyToMode`, `textChunkLimit`, `chunkMode`, `mentionPatterns`.                                                             |
 
 ## Config file
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -139,7 +139,7 @@ you have enabled). Anything you send to any other chat is discarded before its t
 read, logged or stored, and the drop itself is not recorded either — the drop path writes no
 diagnostic line and no log line. The one diagnostic line per inbound batch that precedes it masks every number to its last four digits (a group keeps its identifying form; a legacy `<number>-<timestamp>@g.us` group has its creator's number masked) and carries no message id or text; Baileys' own logging (`info`+, or `debug` under `WHATSAPP_DIAG_DEBUG=1`) is not masked by us.
 
-`catch_up` replays the last **5** messages from the other side and the last **5** of your own per chat, merged in time order, so your own texts never crowd out what the room said. In a mention-gated group it also shows what members said without addressing Claude (tagged "not addressed to Claude") - kept for context only, never routed or counted as unreplied. Your own hand-typed text is
+`catch_up` replays the last **5** messages from the other side and the last **5** of your own per chat, merged in time order, so your own texts never crowd out what the room said. In a mention-gated group it also shows what members said without addressing Claude (tagged "not addressed to Claude") - kept for context only, never routed or counted as unreplied; opt a group out of that with `group add <jid> --no-context` ([ACCESS.md](./ACCESS.md#mention-detection)) and nothing unaddressed is stored for it at all. Your own hand-typed text is
 readable for **1 hour**; after that the line collapses to `<your name> replied (text expired)` —
 the fact that you answered is still shown, the words are not. That is a display rule: the raw
 line stays in `~/.whatsapp-channel/messages.jsonl` for **7 days**, the same as every other

--- a/scripts/access.test.ts
+++ b/scripts/access.test.ts
@@ -428,6 +428,29 @@ describe("groups", () => {
     expect(access(dir).groups["1@g.us"].requireMention).toBe(false);
   });
 
+  test("--no-context opts a group out of no-mention context; omitting it writes no key", () => {
+    const dir = freshStateDir();
+    run(dir, "group", "add", "1@g.us", "--no-context");
+    expect(access(dir).groups["1@g.us"].context).toBe(false);
+    // Default: the key is not materialised at all (absent = kept, 0.22.0).
+    run(dir, "group", "add", "2@g.us");
+    expect("context" in access(dir).groups["2@g.us"]).toBe(false);
+    // Merge preserves it when other flags change...
+    run(dir, "group", "add", "1@g.us", "--roster");
+    expect(access(dir).groups["1@g.us"].context).toBe(false);
+    expect(access(dir).groups["1@g.us"].roster).toBe(true);
+    // ...and --context turns it back on explicitly.
+    run(dir, "group", "add", "1@g.us", "--context");
+    expect(access(dir).groups["1@g.us"].context).toBe(true);
+  });
+
+  test("passing both --context and --no-context together is refused", () => {
+    const dir = freshStateDir();
+    const res = run(dir, "group", "add", "1@g.us", "--context", "--no-context");
+    expect(res.code).toBe(1);
+    expect(existsSync(join(dir, "access.json"))).toBe(false);
+  });
+
   test("passing both --roster and --no-roster together is refused, never silently resolved", () => {
     const dir = freshStateDir();
     const res = run(dir, "group", "add", "1@g.us", "--roster", "--no-roster");

--- a/scripts/access.ts
+++ b/scripts/access.ts
@@ -83,6 +83,9 @@ type GroupPolicy = {
   requireMention: boolean;
   allowFrom: string[];
   roster?: boolean;
+  // false = a no-mention message stores nothing (server.ts is the reader).
+  // Absent = kept for catch_up context, the 0.22.0 default.
+  context?: boolean;
 };
 type PendingEntry = { senderId: string; chatId: string; expiresAt: number };
 type Access = {
@@ -178,7 +181,7 @@ const USAGE = `Usage: bun scripts/access.ts <command>
   forget <jid>                    purge a cached name/activity entry, even
                                    for a JID never allowlisted (see remove)
   policy <${POLICIES.join("|")}>   set the DM policy
-  group add <groupJid> [--mention|--no-mention] [--allow a,b] [--roster|--no-roster]
+  group add <groupJid> [--mention|--no-mention] [--allow a,b] [--roster|--no-roster] [--context|--no-context]
   group rm <groupJid>             stop responding in a group (files kept)
   review                          open the access screen in a NEW terminal
                                    window, wait for it, then print what
@@ -277,7 +280,7 @@ function status(): void {
   for (const [jid, g] of groups) {
     const name = meta[jid]?.name;
     lines.push(
-      `  - ${name ? `${name}  ` : ""}${jid}  mention=${g.requireMention}  roster=${!!g.roster}`,
+      `  - ${name ? `${name}  ` : ""}${jid}  mention=${g.requireMention}  roster=${!!g.roster}${g.context === false ? "  context=false" : ""}`,
     );
   }
   process.stdout.write(lines.join("\n") + "\n");
@@ -352,6 +355,8 @@ function group(args: string[]): void {
         allow: { type: "string" },
         roster: { type: "boolean" },
         "no-roster": { type: "boolean" },
+        context: { type: "boolean" },
+        "no-context": { type: "boolean" },
         backup: { type: "boolean" },
       },
       allowPositionals: true,
@@ -366,6 +371,8 @@ function group(args: string[]): void {
     allow,
     roster = false,
     "no-roster": noRoster = false,
+    context: contextOn = false,
+    "no-context": noContext = false,
     backup,
   } = parsed.values;
   const jid = requireArg(jidArg, "group JID");
@@ -374,6 +381,8 @@ function group(args: string[]): void {
   // ambiguous, never silently resolved one way.
   if (mention && noMention) die("Cannot pass both --mention and --no-mention.");
   if (roster && noRoster) die("Cannot pass both --roster and --no-roster.");
+  if (contextOn && noContext)
+    die("Cannot pass both --context and --no-context.");
   const a = load();
   if (sub === "rm") {
     if (!a.groups[jid]) {
@@ -414,11 +423,16 @@ function group(args: string[]): void {
         : (existing?.allowFrom ?? []),
     roster: roster ? true : noRoster ? false : (existing?.roster ?? false),
   };
+  // Unlike roster, absent means ON here (0.22.0 shipped context kept), so
+  // the key is only materialised once someone has actually set it - a
+  // policy that never mentioned context stays byte-identical.
+  const contextVal = contextOn ? true : noContext ? false : existing?.context;
+  if (contextVal !== undefined) a.groups[jid].context = contextVal;
   save(a, { backup });
 
   const config = provisionGroupFiles(jid);
   process.stdout.write(
-    `${existing ? "Updated" : "Added"} ${jid} (mention required: ${a.groups[jid].requireMention}, roster: ${a.groups[jid].roster}).\nEdit its personality at ${config}\n`,
+    `${existing ? "Updated" : "Added"} ${jid} (mention required: ${a.groups[jid].requireMention}, roster: ${a.groups[jid].roster}, context kept: ${a.groups[jid].context !== false}).\nEdit its personality at ${config}\n`,
   );
 }
 

--- a/scripts/contacts.test.ts
+++ b/scripts/contacts.test.ts
@@ -5,7 +5,9 @@ import {
   hasSavedName,
   mergeContact,
   migrateContactKey,
+  pruneStrangers,
   resolveByName,
+  STRANGER_TTL_MS,
   type ContactsMap,
 } from "./contacts";
 
@@ -257,5 +259,68 @@ describe("hasSavedName", () => {
         "b@s.whatsapp.net": { name: "Akash", notify: "aki_98" },
       }),
     ).toBe(true);
+  });
+});
+
+describe("pruneStrangers", () => {
+  const NOW = 1_756_000_000_000;
+  const OLD = NOW - STRANGER_TTL_MS - 1;
+  const FRESH = NOW - 1000;
+  const J = (n: string) => `${n}@s.whatsapp.net`;
+
+  test("a gate-rejected stranger ages out of both maps", () => {
+    const contacts: ContactsMap = { [J("1")]: { notify: "spam bot" } };
+    const dm = { [J("1")]: OLD };
+    const changed = pruneStrangers(contacts, dm, new Set(), NOW);
+    expect(changed).toEqual({ contacts: true, dms: true });
+    expect(contacts).toEqual({});
+    expect(dm).toEqual({});
+  });
+
+  test("a saved name never ages out, even with stale activity", () => {
+    const contacts: ContactsMap = { [J("2")]: { name: "Mum" } };
+    const dm = { [J("2")]: OLD };
+    pruneStrangers(contacts, dm, new Set(), NOW);
+    expect(contacts[J("2")]).toEqual({ name: "Mum" });
+    // ...but the stale activity timestamp itself still goes: it only ranks
+    // the wizard, and a saved name earns its row without it.
+    expect(dm[J("2")]).toBeUndefined();
+  });
+
+  test("an allowlisted key is kept in both maps whatever its age", () => {
+    const contacts: ContactsMap = { [J("3")]: { notify: "aki_98" } };
+    const dm = { [J("3")]: OLD };
+    const changed = pruneStrangers(contacts, dm, new Set([J("3")]), NOW);
+    expect(changed).toEqual({ contacts: false, dms: false });
+    expect(contacts[J("3")]).toBeDefined();
+    expect(dm[J("3")]).toBe(OLD);
+  });
+
+  test("fresh activity keeps a notify-only contact", () => {
+    const contacts: ContactsMap = { [J("4")]: { notify: "new friend" } };
+    const dm = { [J("4")]: FRESH };
+    const changed = pruneStrangers(contacts, dm, new Set(), NOW);
+    expect(changed).toEqual({ contacts: false, dms: false });
+  });
+
+  test("a notify-only contact with no activity record at all is dropped", () => {
+    const contacts: ContactsMap = { [J("5")]: { notify: "group lurker" } };
+    const changed = pruneStrangers(contacts, {}, new Set(), NOW);
+    expect(changed).toEqual({ contacts: true, dms: false });
+    expect(contacts).toEqual({});
+  });
+
+  test("a malformed activity timestamp is kept, not treated as old", () => {
+    const dm = { [J("6")]: Number.NaN };
+    const changed = pruneStrangers({}, dm, new Set(), NOW);
+    expect(changed.dms).toBe(false);
+    expect(J("6") in dm).toBe(true);
+  });
+
+  test("empty maps report no change", () => {
+    expect(pruneStrangers({}, {}, new Set(), NOW)).toEqual({
+      contacts: false,
+      dms: false,
+    });
   });
 });

--- a/scripts/contacts.ts
+++ b/scripts/contacts.ts
@@ -127,3 +127,50 @@ export function resolveByName(map: ContactsMap, name: string): NameResolution {
     return { ok: false, reason: "ambiguous", candidates: matches };
   return { ok: true, jid: matches[0] };
 }
+
+// ─── Stranger TTL (#30) ─────────────────────────────────────────────────
+// contacts.upsert/chats.upsert fire from Baileys BEFORE the access gate, so
+// one message from a stranger the gate then drops still lands their display
+// name in contacts.json and a timestamp in dm-activity.json. With the cache
+// on by default (0.22.0) and nothing ever pruning it, that record was
+// permanent. This is the one rule that ages those strangers out; the server
+// runs it on the same hourly tick as pruneMessageLog.
+//
+// What NEVER ages out:
+// - a saved name (`.name`) - the owner's own address book, synced from
+//   their phone; forgetting it would undo the address-book sync
+// - an allowlisted key - someone the owner explicitly approved
+// - a notify-only contact with dm-activity younger than the TTL
+export const STRANGER_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Mutates both maps in place (house style - see mergeContact). Returns
+ *  which map actually changed so the caller saves only what moved.
+ *  `allowedKeys` must already be contactKey()-resolved, the same key form
+ *  both maps use. */
+export function pruneStrangers(
+  contacts: ContactsMap,
+  dmActivity: Record<string, number>,
+  allowedKeys: ReadonlySet<string>,
+  now: number = Date.now(),
+  ttlMs: number = STRANGER_TTL_MS,
+): { contacts: boolean; dms: boolean } {
+  let dmsChanged = false;
+  for (const [key, ts] of Object.entries(dmActivity)) {
+    // A malformed timestamp is kept, not dropped: this prune exists to
+    // forget stale strangers, and "we can't tell how old" is not "old".
+    if (typeof ts !== "number" || !Number.isFinite(ts)) continue;
+    if (now - ts < ttlMs) continue;
+    if (allowedKeys.has(key)) continue;
+    delete dmActivity[key];
+    dmsChanged = true;
+  }
+  let contactsChanged = false;
+  for (const [key, entry] of Object.entries(contacts)) {
+    if (entry.name) continue; // saved on the phone - never forgotten here
+    if (allowedKeys.has(key)) continue;
+    if (key in dmActivity) continue; // activity younger than the TTL (above)
+    delete contacts[key];
+    contactsChanged = true;
+  }
+  return { contacts: contactsChanged, dms: dmsChanged };
+}

--- a/scripts/update-notice.ts
+++ b/scripts/update-notice.ts
@@ -57,6 +57,14 @@ if (!isStaticMode()) {
   // latest.
   const CHANGELOG: { version: string; notes: string[] }[] = [
     {
+      version: "0.22.1",
+      notes: [
+        "Mention-gated groups can now opt out of context: `group add <jid> --no-context` restores the stricter meaning of mention gating for that group - nothing members say is stored unless Claude was addressed. Groups that never set it keep context, as 0.22.0 shipped.",
+        "Someone who merely messaged the account and was never approved no longer sits in the contact caches forever: their dm-activity entry ages out after 90 days and an unapproved cached name with no recent activity goes with it. Names saved on your own phone never age out this way.",
+        "The address-book re-sync for a server holding no saved names now asks WhatsApp at most once a day, tracked across restarts - an account with genuinely nothing saved no longer requests a full contact snapshot on every reconnect.",
+      ],
+    },
+    {
       version: "0.22.0",
       notes: [
         'Fixed: the WA:<role> statusline segment was blank for the first few seconds of a session, and because Claude Code only redraws the statusline when you type, it often stayed blank until your first message. A terminal that asked for the WhatsApp channel now shows a dim WA:… straight away, and the server writes its role file earlier, so the real primary/secondary label arrives sooner. Add `"refreshInterval": 5` to your statusLine setting (see USAGE.md) and the label updates on its own instead of waiting for your next keystroke.',

--- a/server.ts
+++ b/server.ts
@@ -69,6 +69,7 @@ import {
   hasSavedName,
   mergeContact,
   migrateContactKey,
+  pruneStrangers,
   type ContactsMap,
 } from "./scripts/contacts";
 import { looksLikeNumber, maskJid, maskNumber } from "./scripts/mask";
@@ -105,6 +106,12 @@ const DM_ACTIVITY_FILE = join(STATE_DIR, "dm-activity.json");
 const MESSAGE_LOG = join(STATE_DIR, "messages.jsonl");
 // Every message id THIS server sent (see trackSent). Never an inbound id.
 const SENT_LOG = join(STATE_DIR, "sent.jsonl");
+// Epoch-ms of the last address-book resync attempt (see syncSavedNamesOnce).
+// On disk, not in memory: the in-process cooldown resets every time the
+// watchdog cycles the server, and for an account with genuinely zero saved
+// names "no name cached yet" is permanent - without this, every connect
+// would null the app-state version and demand a full snapshot forever.
+const ADDRESS_BOOK_SYNC_MARKER = join(STATE_DIR, ".addressbook-sync");
 const TASKS_FILE = join(STATE_DIR, "tasks.md");
 const LOCK_FILE = join(STATE_DIR, ".server.lock");
 const IPC_TOKEN_FILE = join(STATE_DIR, ".ipc-token");
@@ -1053,6 +1060,12 @@ type GroupPolicy = {
   // (`?? false`/`!!`) everywhere - a policy written before this field
   // existed has no `roster` key at all, not an explicit false.
   roster?: boolean;
+  // false = a no-mention message in this group is stored NOWHERE - restores
+  // the pre-0.22 meaning of mention gating ("Claude only ever sees messages
+  // that mention it"). Absent/true = kept text-only for catch_up context
+  // (routed: false), the 0.22.0 default. Read as `!== false` everywhere so
+  // a policy written before this field existed keeps context.
+  context?: boolean;
 };
 
 type Access = {
@@ -1499,9 +1512,25 @@ async function refreshGroupsMeta(
 // (lib/Socket/chats.js:824-834). A resync re-sends in full only for a
 // collection at version 0 (chats.js:376-384), so clear it first - Baileys'
 // own recovery move (chats.js:437) via its authState.keys API. Only
-// critical_unblock_low carries contactAction (chat-utils.js:440-449). Guard
-// is the cache on disk plus the reconnect-storm cooldown, never a flag.
+// critical_unblock_low carries contactAction (chat-utils.js:440-449). Guards
+// are the cache on disk, the reconnect-storm cooldown, and the once-a-day
+// on-disk marker below.
 let addressBookSyncAttemptedAt = 0;
+
+// Across restarts: one attempt per day, however often the server cycles.
+// Still self-healing (a phone that saves its first contact tomorrow gets
+// synced tomorrow), but an account with zero saved names costs one full
+// snapshot a day, not one per reconnect (#29).
+const ADDRESS_BOOK_SYNC_RETRY_MS = 24 * 60 * 60 * 1000;
+
+function lastAddressBookSyncMs(): number {
+  try {
+    const t = Number(readFileSync(ADDRESS_BOOK_SYNC_MARKER, "utf8").trim());
+    return Number.isFinite(t) ? t : 0;
+  } catch {
+    return 0;
+  }
+}
 
 async function syncSavedNamesOnce(
   activeSock: NonNullable<typeof sock>,
@@ -1511,7 +1540,16 @@ async function syncSavedNamesOnce(
   if (hasSavedName(contactsMap)) return;
   if (Date.now() - addressBookSyncAttemptedAt < GROUPS_META_CONNECT_COOLDOWN_MS)
     return;
+  if (Date.now() - lastAddressBookSyncMs() < ADDRESS_BOOK_SYNC_RETRY_MS) return;
   addressBookSyncAttemptedAt = Date.now();
+  // Written BEFORE the resync, same as the in-process stamp: a resync that
+  // throws still counts as today's attempt, or a socket that rejects it
+  // would put us right back in the retry-every-connect loop.
+  try {
+    writeFileSync(ADDRESS_BOOK_SYNC_MARKER, String(Date.now()), {
+      mode: 0o600,
+    });
+  } catch {}
   // Typed on the rc.9 socket (Socket/index.d.ts:178); checked at runtime
   // anyway so a Baileys that drops it degrades to "no names" rather than
   // throwing inside the connection handler.
@@ -1612,7 +1650,7 @@ function pruneExpired(a: Access): boolean {
 
 type GateResult =
   | { action: "deliver"; access: Access }
-  | { action: "drop"; reason?: "no-mention" }
+  | { action: "drop"; reason?: "no-mention"; keepContext?: boolean }
   | { action: "pair"; code: string; isResend: boolean };
 
 function gate(
@@ -1678,9 +1716,16 @@ function gate(
     requireMention &&
     !isMentioned(text, mentionedJids, access.mentionPatterns)
   ) {
-    // The one drop the log keeps (see handleMessage): the group is
+    // The one drop the log CAN keep (see handleMessage): the group is
     // configured and the sender is allowed, the message just was not for us.
-    return { action: "drop", reason: "no-mention" };
+    // Unless the owner opted this group out (`context: false`), in which
+    // case even this drop stores nothing - decided here, where the policy
+    // is already in hand, so handleMessage never re-reads access for a drop.
+    return {
+      action: "drop",
+      reason: "no-mention",
+      keepContext: policy.context !== false,
+    };
   }
   return { action: "deliver", access };
 }
@@ -2212,12 +2257,39 @@ function pruneSentLog(): void {
   } catch {}
 }
 
+/** Age gate-rejected strangers out of contacts.json / dm-activity.json
+ *  (#30). Rides the same hourly tick as pruneMessageLog. Reloads both maps
+ *  first, the same reason reloadContactsMap exists at all: scripts/access.ts
+ *  mutates these files between our writes. */
+function pruneStrangerCaches(): void {
+  if (!CACHE_CONTACTS) return; // nothing persists anyway
+  try {
+    reloadContactsMap();
+    reloadDmActivity();
+    const access = loadAccess();
+    // Everyone with standing approval, in the key form both caches use.
+    // Group allowFrom entries count too: someone approved for a group only
+    // is still someone the owner named, not a stranger.
+    const allowed = new Set<string>();
+    for (const jid of access.allowFrom) allowed.add(contactKey(jid));
+    for (const g of Object.values(access.groups))
+      for (const jid of g.allowFrom ?? []) allowed.add(contactKey(jid));
+    if (ownJid) allowed.add(contactKey(ownJid));
+    const changed = pruneStrangers(contactsMap, dmActivity, allowed);
+    if (changed.contacts) saveContactsMap();
+    if (changed.dms) saveDmActivity();
+  } catch (err) {
+    logDiag(`${LOG_PREFIX}: stranger-cache prune failed: ${err}\n`);
+  }
+}
+
 /** Prune the log: open inbounds after 24h, context lines after 7 days (keepLogLine) */
 function pruneMessageLog(): void {
   // First: pruneMessageLog returns early when messages.jsonl does not exist
   // yet, and sent.jsonl can exist without it (pairing notices go to chats
   // that are never logged).
   pruneSentLog();
+  pruneStrangerCaches();
   try {
     if (!existsSync(MESSAGE_LOG)) return;
     // Two lifetimes, decided in lib/message-view.ts: a routed inbound is a
@@ -3518,7 +3590,7 @@ async function handleMessage(msg: WAMessage, backlog = false): Promise<void> {
     // room when the owner wants to write to it. It is never routed, notified
     // or counted as unreplied - `routed: false` is what getUnreplied and the
     // catch_up counter key on. Every other drop reason stores nothing.
-    if (isGroup && result.reason === "no-mention") {
+    if (isGroup && result.reason === "no-mention" && result.keepContext) {
       // Same content rule as the delivered path: real media becomes
       // "(image)" etc.; reactions, edits, revokes and poll updates carry no
       // content and are not kept.


### PR DESCRIPTION
Closes #29, closes #30, closes #31 — the three follow-ups from the #28 review. One cut: **0.22.1**.

## What changed

**#29 — address-book resync is once a day, across restarts.** `syncSavedNamesOnce` now also checks an on-disk marker (`~/.whatsapp-channel/.addressbook-sync`, epoch-ms, written *before* the attempt so a throwing resync still counts). The in-process 5-min cooldown stays as the reconnect-storm guard; the marker is what survives the watchdog cycling the server. An account with genuinely zero saved names now costs one full app-state snapshot per day instead of one per reconnect.

**#30 — strangers age out of the contact caches.** New pure `pruneStrangers()` in `scripts/contacts.ts` (7 tests), wired onto the existing hourly `pruneMessageLog` tick. Rules: a `dm-activity.json` entry older than **90 days** is dropped unless its key is allowlisted (DM `allowFrom`, any group's `allowFrom`, or the owner); a `contacts.json` entry with **no saved name** is dropped once it has neither an allowlist entry nor surviving activity. A saved name (the owner's own phone address book) never ages out. Reloads both maps first so a concurrent `access.ts` write is never clobbered; malformed timestamps are kept, not treated as old.

**#31 — mention-gated context is per-group now.** `GroupPolicy.context?: boolean`: `group add <jid> --no-context` restores the stricter pre-0.22 meaning of mention gating for that group — nothing members say is stored unless Claude was addressed. `--context` turns it back on; a policy that never set it keeps context (the 0.22.0 default) and stays byte-identical — the key is only materialised when someone sets it, and `group add`'s merge preserves it. The decision lives in `gate()` (the policy is already in hand there; `handleMessage` never re-reads access for a drop) and the picker's byte-identical-keep rule already preserves the flag. Documented in ACCESS.md's Groups + Mention detection sections and USAGE.md's catch_up paragraph.

## Danger-zone invariants (AGENTS.md rule 2)

- Connection lifecycle: untouched except one added early-return guard in `syncSavedNamesOnce` (fire-and-forget, already `.catch()`-wrapped at the call site).
- Singleton lock: untouched.
- Access gating: `gate()`'s decision surface is unchanged — the no-mention branch returns the same `drop` action, now carrying `keepContext`; who is delivered/dropped/paired is byte-for-byte the same as 0.22.0.

## Tests

`bun test`: 451 pass / 1 skip / 1 fail — the failure is `access.test.ts` "review > spawn argv" on macOS only (`/var` vs `/private/var` realpath in the fixture, pre-existing on main, passes on CI ubuntu). New: 7 `pruneStrangers` cases, 2 `--context/--no-context` CLI cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QW6HZCUvDvZRnydMv9Gfw4