### PR TITLE
fix: transcribe voice/audio before the mention gate in requireMention groups

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "whatsapp-channel",
       "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control, pairing, allowlists, and group policy.",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "source": "./",
       "category": "channels"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "whatsapp-channel",
   "displayName": "WhatsApp Channel for Claude Code",
   "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /whatsapp-channel:access.",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "author": {
     "name": "Rich627"
   },

--- a/server.ts
+++ b/server.ts
@@ -3572,6 +3572,61 @@ async function handleMessage(msg: WAMessage, backlog = false): Promise<void> {
   // because our passive lid-mapping.update listener missed it.
   await ensureLidResolved(senderJid);
 
+  // A voice/audio message carries no caption and no native WhatsApp
+  // @-mention — `text` is empty until it is transcribed. A mention-gated
+  // group would otherwise drop it on `text` alone before anyone finds out
+  // what was actually said, even when the recording opens with the wake
+  // word. Transcribe once, here, before the gate runs, so the mention check
+  // sees real content instead of nothing. Scoped tight to avoid wasted
+  // transcription: only when the drop is otherwise certain (group,
+  // requireMention on, no native mention already) and only for live
+  // messages, matching the `!backlog` guard the normal media path uses
+  // below.
+  let earlyAudioPath: string | undefined;
+  let earlyAudioTranscript: string | null | undefined;
+  if (isGroup && !backlog && sock) {
+    const groupPolicy = loadAccess().groups[remoteJid];
+    const groupAllowFrom = groupPolicy?.allowFrom ?? [];
+    const senderAllowed =
+      groupAllowFrom.length === 0 || isAllowedJid(senderJid, groupAllowFrom);
+    const alreadyMentioned = mentionedJids.some(
+      (jid) => ownJid && jidNormalizedUser(jid) === ownJid,
+    );
+    const media =
+      groupPolicy?.requireMention && senderAllowed
+        ? classifyMedia(msg.message)
+        : null;
+    if (
+      groupPolicy?.requireMention &&
+      senderAllowed &&
+      !alreadyMentioned &&
+      (media?.kind === "voice" || media?.kind === "audio")
+    ) {
+      try {
+        const buffer = (await downloadMediaMessage(
+          msg,
+          "buffer",
+          {},
+          { reuploadRequest: sock.updateMediaMessage, logger: silentLogger },
+        )) as Buffer;
+        const ext = mimeToExt(media.mime);
+        earlyAudioPath = join(
+          INBOX_DIR,
+          `${Date.now()}-${messageId.replace(/[^a-zA-Z0-9]/g, "").slice(0, 16)}.${ext}`,
+        );
+        writeFileSync(earlyAudioPath, buffer);
+        earlyAudioTranscript = await transcribeAudio(earlyAudioPath);
+        if (earlyAudioTranscript) {
+          text = `[Voice message] ${earlyAudioTranscript}`;
+        }
+      } catch (err) {
+        logDiag(
+          `${LOG_PREFIX}: early voice transcribe (pre-gate) failed: ${err}\n`,
+        );
+      }
+    }
+  }
+
   // Gate check
   const result = gate(remoteJid, senderJid, text, mentionedJids, !backlog);
 
@@ -3743,27 +3798,13 @@ async function handleMessage(msg: WAMessage, backlog = false): Promise<void> {
         logDiag(`${LOG_PREFIX}: image download failed: ${err}\n`);
       }
     } else if (media.kind === "voice" || media.kind === "audio") {
-      // Eager download + transcribe voice/audio messages
-      try {
-        const buffer = (await downloadMediaMessage(
-          msg,
-          "buffer",
-          {},
-          {
-            reuploadRequest: sock!.updateMediaMessage,
-            logger: silentLogger,
-          },
-        )) as Buffer;
-        const ext = mimeToExt(media.mime);
-        const audioPath = join(
-          INBOX_DIR,
-          `${Date.now()}-${messageId.replace(/[^a-zA-Z0-9]/g, "").slice(0, 16)}.${ext}`,
-        );
-        writeFileSync(audioPath, buffer);
-        const transcript = await transcribeAudio(audioPath);
-        if (transcript) {
-          // Replace text with transcript — Claude sees it as a regular text message
-          text = `[Voice message] ${transcript}`;
+      // Eager download + transcribe voice/audio messages. A mention-gated
+      // group already did this above (pre-gate, to decide whether the
+      // message was for us at all) — reuse that result instead of
+      // downloading and transcribing the same note twice.
+      if (earlyAudioPath !== undefined) {
+        if (earlyAudioTranscript) {
+          text = `[Voice message] ${earlyAudioTranscript}`;
         } else {
           attachment = {
             kind: media.kind,
@@ -3771,13 +3812,42 @@ async function handleMessage(msg: WAMessage, backlog = false): Promise<void> {
             ...(media.mime ? { mime: media.mime } : {}),
           };
         }
-      } catch (err) {
-        logDiag(`${LOG_PREFIX}: voice download/transcribe failed: ${err}\n`);
-        attachment = {
-          kind: media.kind,
-          file_id: messageId,
-          ...(media.mime ? { mime: media.mime } : {}),
-        };
+      } else {
+        try {
+          const buffer = (await downloadMediaMessage(
+            msg,
+            "buffer",
+            {},
+            {
+              reuploadRequest: sock!.updateMediaMessage,
+              logger: silentLogger,
+            },
+          )) as Buffer;
+          const ext = mimeToExt(media.mime);
+          const audioPath = join(
+            INBOX_DIR,
+            `${Date.now()}-${messageId.replace(/[^a-zA-Z0-9]/g, "").slice(0, 16)}.${ext}`,
+          );
+          writeFileSync(audioPath, buffer);
+          const transcript = await transcribeAudio(audioPath);
+          if (transcript) {
+            // Replace text with transcript — Claude sees it as a regular text message
+            text = `[Voice message] ${transcript}`;
+          } else {
+            attachment = {
+              kind: media.kind,
+              file_id: messageId,
+              ...(media.mime ? { mime: media.mime } : {}),
+            };
+          }
+        } catch (err) {
+          logDiag(`${LOG_PREFIX}: voice download/transcribe failed: ${err}\n`);
+          attachment = {
+            kind: media.kind,
+            file_id: messageId,
+            ...(media.mime ? { mime: media.mime } : {}),
+          };
+        }
       }
     } else {
       // Lazy download for video, documents, stickers


### PR DESCRIPTION
## What & why

A voice/audio message carries no caption and WhatsApp gives it no native
`@`-mention slot, so `text` is empty by the time `gate()` runs. In a group
with `requireMention` on, `isMentioned()` tests that empty text and always
fails — the message is dropped before it is ever downloaded or transcribed,
no matter what is actually said in the recording (even the wake word
itself).

Text messages are unaffected. Only `requireMention` groups receiving
audio hit this — the same audio sent to a DM (no mention gate at all)
transcribes fine, which is what made the asymmetry visible: identical
voice note, DM works, group silently drops it. `diag.log` confirmed
`dropped inbound` entries at the exact timestamps of the group sends,
with nothing downloaded.

## Fix

In `handleMessage`, before the `gate()` call, detect the one shape where
the drop is otherwise certain (group, `requireMention` on, sender allowed
per `allowFrom`, no native mention already present) and transcribe once,
ahead of `gate()`, folding the transcript into `text` so `isMentioned()`
can see what was actually said instead of nothing. The existing eager
download/transcribe path further down (unchanged in its own logic) now
checks for that early result first and reuses it instead of downloading
and transcribing the same note twice.

`gate()` itself is untouched — same signature, same logic, same DM
handling. The new code only ever runs to decide a group-audio drop that
`requireMention` would otherwise make unconditionally, and only for live
messages (`!backlog`), matching the guard the normal media-download path
already uses. Allowlist/access gating invariant preserved: the early path
replicates the exact same `allowFrom` check `gate()` uses, so a
not-allowed sender's audio is never transcribed just to be dropped anyway.

## How I tested it

- `bun test` — 452 pass / 1 skip / 0 fail (full existing suite, unchanged).
- `bunx prettier --check` — clean (matches the file's existing style; the
  original file was already prettier-clean before my change, confirmed by
  diffing against a pristine `origin/main` copy).
- Manual trace-through against a real capture: reproduced the bug against a
  live instance first (group with `requireMention: true`, plain voice note
  → silently dropped, `diag.log` shows the drop at the same timestamp,
  nothing in the inbox), confirmed the code path (`gate()` runs on
  `extractText()`'s output, which is `""` for a bare `audioMessage`, before
  the download/transcribe block later in the function), then applied and
  reasoned through this fix against that same trace.
- Could not run `trunk check` — a fresh clone of this repo has no `.trunk/`
  config, so the launcher asks for `trunk init` rather than checking. I
  don't have access to whatever org-level config CI resolves, so please
  let CI's `trunk` job be the real check here; happy to adjust for
  anything it flags.
- Did not add an automated regression test: `gate()`/`handleMessage`
  aren't exported or exercised by the existing suite (nothing in
  `lib/*.test.ts` or `scripts/*.test.ts` touches them), and there's no
  existing harness for the live-socket-shaped parts of `handleMessage`.
  Open to pointers if there's a preferred way to cover this that I missed.

## Checklist

- [ ] I ran `trunk fmt` and `trunk check` and it passes. — see note above;
  could not run locally (no `.trunk/` config in a fresh clone), ran
  `bun test` + `prettier --check` instead.
- [x] Version bumped in BOTH files to the same new version (0.22.1 → 0.22.2, patch):
  - [x] `.claude-plugin/plugin.json` → `version`
  - [x] `.claude-plugin/marketplace.json` → `plugins[0].version`
- [x] No new runtime dependencies.
- [x] No runtime state / secrets committed.
- [x] Touched access/allowlist gating (see "Fix" section above for the
  invariant preserved) — did not touch connection lifecycle or the
  singleton lock.