### PR TITLE
Send documents with a real mimetype so Android WhatsApp can open them

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,8 +9,8 @@
   "plugins": [
     {
       "name": "whatsapp-channel",
-      "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control, pairing, allowlists, and group policy.",
-      "version": "0.23.0",
+      "description": "WhatsApp channel for Claude Code \u2014 linked-device messaging bridge with built-in access control, pairing, allowlists, and group policy.",
+      "version": "0.23.1",
       "source": "./",
       "category": "channels"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "whatsapp-channel",
-      "description": "WhatsApp channel for Claude Code \u2014 linked-device messaging bridge with built-in access control, pairing, allowlists, and group policy.",
+      "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control, pairing, allowlists, and group policy.",
       "version": "0.23.1",
       "source": "./",
       "category": "channels"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "whatsapp-channel",
   "displayName": "WhatsApp Channel for Claude Code",
-  "description": "WhatsApp channel for Claude Code \u2014 linked-device messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /whatsapp-channel:access.",
+  "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /whatsapp-channel:access.",
   "version": "0.23.1",
   "author": {
     "name": "Rich627"
@@ -9,10 +9,5 @@
   "homepage": "https://github.com/Rich627/whatsapp-claude-plugin",
   "repository": "https://github.com/Rich627/whatsapp-claude-plugin",
   "license": "Apache-2.0",
-  "keywords": [
-    "whatsapp",
-    "messaging",
-    "channel",
-    "mcp"
-  ]
+  "keywords": ["whatsapp", "messaging", "channel", "mcp"]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,18 @@
 {
   "name": "whatsapp-channel",
   "displayName": "WhatsApp Channel for Claude Code",
-  "description": "WhatsApp channel for Claude Code — linked-device messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /whatsapp-channel:access.",
-  "version": "0.23.0",
+  "description": "WhatsApp channel for Claude Code \u2014 linked-device messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /whatsapp-channel:access.",
+  "version": "0.23.1",
   "author": {
     "name": "Rich627"
   },
   "homepage": "https://github.com/Rich627/whatsapp-claude-plugin",
   "repository": "https://github.com/Rich627/whatsapp-claude-plugin",
   "license": "Apache-2.0",
-  "keywords": ["whatsapp", "messaging", "channel", "mcp"]
+  "keywords": [
+    "whatsapp",
+    "messaging",
+    "channel",
+    "mcp"
+  ]
 }

--- a/scripts/update-notice.ts
+++ b/scripts/update-notice.ts
@@ -57,6 +57,12 @@ if (!isStaticMode()) {
   // latest.
   const CHANGELOG: { version: string; notes: string[] }[] = [
     {
+      version: "0.23.1",
+      notes: [
+        "Documents you send (PDFs, markdown, spreadsheets, audio files) now arrive with their real file type. They used to be sent as a generic binary, which Android WhatsApp showed as an unopenable BIN file.",
+      ],
+    },
+    {
       version: "0.23.0",
       notes: [
         "Fixed a message loss that was easy to mistake for the channel being asleep: a message that arrived within a fraction of a second of Claude sending a reply was filed as old backlog, so you got no notification, no ack, and any photo or voice note in it was never downloaded. It was likeliest right after a long reply, because each chunk reopened the window.",

--- a/server.ts
+++ b/server.ts
@@ -2584,6 +2584,29 @@ function mimeToExt(mime: string | null | undefined): string {
   return map[mime.split(";")[0].trim()] ?? "bin";
 }
 
+
+// Declared mimetype for outbound documents. Android WhatsApp labels and opens an attachment by this
+// value, so "application/octet-stream" shows up as an unopenable "BIN" file.
+function mimeForExt(ext: string): string {
+  const m: Record<string, string> = {
+    ".pdf": "application/pdf",
+    ".md": "text/markdown",
+    ".txt": "text/plain",
+    ".csv": "text/csv",
+    ".json": "application/json",
+    ".html": "text/html",
+    ".zip": "application/zip",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".mp3": "audio/mpeg",
+    ".m4a": "audio/mp4",
+    ".ogg": "audio/ogg",
+    ".wav": "audio/wav",
+  };
+  return m[ext.toLowerCase()] ?? "application/octet-stream";
+}
+
 // ─── MCP Server ────────────────────────────────────────────────────────
 
 let sock: WASocket | null = null;
@@ -3148,7 +3171,7 @@ const handleToolCall = async (req: {
             sent = (await sock.sendMessage(chat_id, {
               document: buf,
               fileName: basename(f),
-              mimetype: "application/octet-stream",
+              mimetype: mimeForExt(ext),
             })) as WAMessage | undefined;
           }
           if (sent?.key) {

--- a/server.ts
+++ b/server.ts
@@ -2584,7 +2584,6 @@ function mimeToExt(mime: string | null | undefined): string {
   return map[mime.split(";")[0].trim()] ?? "bin";
 }
 
-
 // Declared mimetype for outbound documents. Android WhatsApp labels and opens an attachment by this
 // value, so "application/octet-stream" shows up as an unopenable "BIN" file.
 function mimeForExt(ext: string): string {
@@ -2596,9 +2595,12 @@ function mimeForExt(ext: string): string {
     ".json": "application/json",
     ".html": "text/html",
     ".zip": "application/zip",
-    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".docx":
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".xlsx":
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".pptx":
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     ".mp3": "audio/mpeg",
     ".m4a": "audio/mp4",
     ".ogg": "audio/ogg",


### PR DESCRIPTION
Outbound attachments that aren't images or videos are sent as `application/octet-stream`, which Android WhatsApp shows as an unopenable "BIN" file.

This maps common extensions (pdf, md, txt, csv, json, html, zip, docx/xlsx/pptx, mp3/m4a/ogg/wav) to their mimetypes in the document branch of `reply`, and keeps `application/octet-stream` as the fallback for anything else, so behaviour for unknown types is unchanged.

Tested on 0.22.1 with a PDF sent to Android WhatsApp: shows and opens as a PDF.